### PR TITLE
Signing should only be enabled while publishing releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,5 +92,6 @@ publishing {
 }
 
 signing {
+    required = { gradle.taskGraph.hasTask(publish) && !version.endsWith("SNAPSHOT") }
     sign publishing.publications.maven
 }


### PR DESCRIPTION
This PR helps to disable signing while releasing snapshots.