### PR TITLE
bypass issue where lambda's are eagerly initialized

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -81,6 +81,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         String nativeImage = getNativeImagePath(config);
         ProcessBuilder compileBuilder = new ProcessBuilder(nativeImage);
         compileBuilder.command().add("--report-unsupported-elements-at-runtime");
+        compileBuilder.command().add("-Djdk.internal.lambda.eagerlyInitialize=false");
         compileBuilder.command().add("-H:+ExitAfterRelocatableImageWrite");
         compileBuilder.command().add("-H:TempDirectory="+tmpDir);
         compileBuilder.command().add("-H:+SharedLibrary");


### PR DESCRIPTION
This will be fixed in GraalVM, but the issue is circumvented by
providing -Djdk.internal.lambda.eagerlyInitialize=false to native-image