### PR TITLE
#65: custom llc location 

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -121,5 +121,6 @@ public class Constants {
     public static final String JNI_JAVAFX_ARCH_FILE = "jniconfig-javafx-${archOs}.json";
     public static final String JNI_ARCH_FILE = "jniconfig-${archOs}.json";
 
+    public static final String LLC_NAME = "llc";
     public static final String LLC_VERSION = "1";
 }

--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -121,4 +121,5 @@ public class Constants {
     public static final String JNI_JAVAFX_ARCH_FILE = "jniconfig-javafx-${archOs}.json";
     public static final String JNI_ARCH_FILE = "jniconfig-${archOs}.json";
 
+    public static final String LLC_VERSION = "1";
 }

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -59,13 +59,8 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
 
     private List<String> defaultAdditionalSourceFiles = Arrays.asList("launcher.c");
 
-    String processClassPath(String cp) {
-        return cp;
-    }
-
     @Override
     public boolean compile(ProcessPaths paths, ProjectConfiguration config, String cp) throws IOException, InterruptedException {
-        String classPath = processClassPath(cp);
         this.projectConfiguration = config;
         this.paths = paths;
         Triplet target =  config.getTargetTriplet();
@@ -100,7 +95,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         compileBuilder.command().add("-Dsvm.platform=org.graalvm.nativeimage.Platform$"+jniPlatform);
         compileBuilder.command().add("-cp");
-        compileBuilder.command().add(classPath);
+        compileBuilder.command().add(cp);
         compileBuilder.command().add(mainClassName);
         Path workDir = gvmPath.resolve(projectConfiguration.getAppName());
         compileBuilder.directory(workDir.toFile());

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -458,7 +458,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return Collections.emptyList();
     }
 
-    List<String> getTargetSpecificAOTCompileFlags() {
+    List<String> getTargetSpecificAOTCompileFlags() throws IOException {
         return Collections.emptyList();
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -59,8 +59,13 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
 
     private List<String> defaultAdditionalSourceFiles = Arrays.asList("launcher.c");
 
+    String processClassPath(String cp) {
+        return cp;
+    }
+
     @Override
     public boolean compile(ProcessPaths paths, ProjectConfiguration config, String cp) throws IOException, InterruptedException {
+        String classPath = processClassPath(cp);
         this.projectConfiguration = config;
         this.paths = paths;
         Triplet target =  config.getTargetTriplet();
@@ -95,7 +100,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         compileBuilder.command().add("-Dsvm.platform=org.graalvm.nativeimage.Platform$"+jniPlatform);
         compileBuilder.command().add("-cp");
-        compileBuilder.command().add(cp);
+        compileBuilder.command().add(classPath);
         compileBuilder.command().add(mainClassName);
         Path workDir = gvmPath.resolve(projectConfiguration.getAppName());
         compileBuilder.directory(workDir.toFile());

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -194,12 +194,6 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
         return appPath.toString() + "/" + appName;
     }
 
-    @Override
-    String processClassPath(String cp) {
-        System.err.println("Process class path: "+cp);
-        return cp;
-    }
-
     private String getArch() {
         return projectConfiguration.getTargetTriplet().getArch();
     }

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -111,7 +111,7 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
     Path getLlcPath() throws IOException {
         if (projectConfiguration.getLlcPath() != null) {
             Path llcPath = Path.of(projectConfiguration.getLlcPath());
-            if (!llcPath.toFile().exists()) {
+            if (!Files.exists(llcPath)) {
                 throw new IllegalArgumentException("Configuration points to an llc that does not exist: "+llcPath);
             } else {
                 return llcPath;
@@ -192,6 +192,12 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
             }
         }
         return appPath.toString() + "/" + appName;
+    }
+
+    @Override
+    String processClassPath(String cp) {
+        System.err.println("Process class path: "+cp);
+        return cp;
     }
 
     private String getArch() {

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -30,6 +30,7 @@ package com.gluonhq.substrate.target;
 import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.model.ProjectConfiguration;
+import com.gluonhq.substrate.util.FileDeps;
 import com.gluonhq.substrate.util.FileOps;
 import com.gluonhq.substrate.util.Logger;
 import com.gluonhq.substrate.util.XcodeUtils;
@@ -87,13 +88,38 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
-    List<String> getTargetSpecificAOTCompileFlags() {
-        Path llcPath = Path.of(projectConfiguration.getGraalPath(),"bin", "llc");
+    List<String> getTargetSpecificAOTCompileFlags() throws IOException {
+
+        Path llcPath = getLlcPath();
         return Arrays.asList("-H:CompilerBackend=" + Constants.BACKEND_LLVM,
                 "-H:-SpawnIsolates",
                 "-Dsvm.targetName=iOS",
                 "-Dsvm.targetArch=" + getArch(),
                 "-H:CustomLLC=" + llcPath.toAbsolutePath().toString());
+    }
+
+    /*
+     * Returns the path to an llc compiler
+     * First, the projectConfiguration is checked for llcPath.
+     * If that property is set, it will be used. If the property is set, but the llc compiler is not at the
+     * pointed location or is not working, an IllegalArgumentException will be thrown.
+     *
+     * If there is no llcPath property in the projectConfiguration, the file cache is checked for an llc version
+     * that works for the current architecture.
+     * If there is no llc in the file cache, it is retrieved from the download site, and added to the cache.
+     */
+    Path getLlcPath() throws IOException {
+        if (projectConfiguration.getLlcPath() != null) {
+            Path llcPath = Path.of(projectConfiguration.getLlcPath());
+            if (!llcPath.toFile().exists()) {
+                throw new IllegalArgumentException("Configuration points to an llc that does not exist: "+llcPath);
+            } else {
+                return llcPath;
+            }
+        }
+        // there is no pre-configured llc, search it in the cache, or populare the cache
+        Path llcPath = FileDeps.getLlcPath(projectConfiguration);
+        return llcPath;
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -260,6 +260,7 @@ public class FileDeps {
              ObjectInputStream ois = new ObjectInputStream(fis)) {
             hashes = (Map<String, String>) ois.readObject();
         } catch (IOException | ClassNotFoundException e) {
+            Logger.logDebug("Exception trying to get hashmap for "+nameFile+": "+e);
             return null;
         }
         return hashes;

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -44,6 +44,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -242,13 +243,24 @@ public class FileDeps {
         return llcPath;
     }
 
+    /**
+     * Return the hashmap associated with this nameFile.
+     * If a file named <code>nameFile</code> exists, and it contains  a serialized version of a Map, this
+     * Map will be returned.
+     * If the file doesn't exist or is corrupt, this method returns null
+     * @param nameFile
+     * @return the Map contained in the file named nameFile, or null in all other cases.
+     */
     private static Map<String, String> getHashMap(String nameFile) {
         Map<String, String> hashes = null;
+        if (!Files.exists(Paths.get(nameFile))) {
+            return null;
+        }
         try (FileInputStream fis = new FileInputStream(new File(nameFile));
              ObjectInputStream ois = new ObjectInputStream(fis)) {
             hashes = (Map<String, String>) ois.readObject();
-        } catch (ClassNotFoundException | IOException e) {
-            e.printStackTrace();
+        } catch (IOException | ClassNotFoundException e) {
+            return null;
         }
         return hashes;
     }

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -45,13 +45,16 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -239,6 +242,10 @@ public class FileDeps {
         FileOutputStream fileOutputStream = new FileOutputStream(llcPath.toFile());
         FileChannel fileChannel = fileOutputStream.getChannel();
         fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        Set<PosixFilePermission> perms = new HashSet<>();
+        perms.add(PosixFilePermission.OWNER_READ);
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(llcPath, perms);
         // now llcPath contains the llc, return it.
         return llcPath;
     }

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -237,11 +237,16 @@ public class FileDeps {
             return llcPath;
         }
         // we don't have the required llc. Download it and store it in llcPath.
+
         URL url = new URL(LLC_URL+llcname);
-        ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
-        FileOutputStream fileOutputStream = new FileOutputStream(llcPath.toFile());
-        FileChannel fileChannel = fileOutputStream.getChannel();
-        fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        try (ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
+             FileOutputStream fileOutputStream = new FileOutputStream(llcPath.toFile());
+             FileChannel fileChannel = fileOutputStream.getChannel()) {
+            fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+            readableByteChannel.close();
+        } catch (IOException e) {
+            throw new IOException("Error downloading LLC from " + url + ": " + e.getMessage() + ", " + e.getSuppressed());
+        }
         Set<PosixFilePermission> perms = new HashSet<>();
         perms.add(PosixFilePermission.OWNER_READ);
         perms.add(PosixFilePermission.OWNER_EXECUTE);

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -221,15 +221,15 @@ public class FileDeps {
      * @throws IOException in case the required directories can't be created or navigated into.
      */
     public static Path getLlcPath(ProjectConfiguration configuration) throws IOException {
-        Path llcRootPath = Constants.USER_SUBSTRATE_PATH.resolve("llc");
+        Path llcRootPath = Constants.USER_SUBSTRATE_PATH.resolve(Constants.LLC_NAME);
         String archos = configuration.getHostTriplet().getArchOs();
         Path archosPath = llcRootPath.resolve(archos).resolve(Constants.LLC_VERSION);
-        if (!archosPath.toFile().exists()) {
-            archosPath.toFile().mkdirs();
+        if (!Files.exists(archosPath)) {
+            Files.createDirectories(archosPath);
         }
         String llcname = "llc-"+archos+"-"+Constants.LLC_VERSION;
         Path llcPath = archosPath.resolve(llcname);
-        if (llcPath.toFile().exists()) {
+        if (Files.exists(llcPath)) {
             return llcPath;
         }
         // we don't have the required llc. Download it and store it in llcPath.
@@ -237,7 +237,7 @@ public class FileDeps {
         ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
         FileOutputStream fileOutputStream = new FileOutputStream(llcPath.toFile());
         FileChannel fileChannel = fileOutputStream.getChannel();
-        fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
         // now llcPath contains the llc, return it.
         return llcPath;
     }


### PR DESCRIPTION
With this PR, the llc compiler, if required (e.g. when the LLVM backend is used) will be searched for in the following order:
1. if a property `llcPath` exists on the `ProjectConfiguration`, it should point to a valid llc
2. If there is a matching (arch/os/version) llc in the file cache, that will be used
3. if there is no matching llc, one will be downloaded and installed in cache.