### PR TITLE
Refactor `FileDeps` to simplify multiple APIs 

### DIFF
--- a/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
+++ b/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
@@ -30,7 +30,7 @@ package com.gluonhq.substrate;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.model.ProjectConfiguration;
 import com.gluonhq.substrate.model.Triplet;
-import com.gluonhq.substrate.target.TargetConfiguration;
+import com.gluonhq.substrate.target.*;
 import com.gluonhq.substrate.util.Logger;
 
 import java.io.File;
@@ -150,7 +150,6 @@ public class SubstrateDispatcher {
         System.err.println("Usage:\n java -Dimagecp=... -Dgraalvm=... -Dmainclass=... com.gluonhq.substrate.SubstrateDispatcher");
     }
 
-
     private final Path buildRoot;
     private final ProjectConfiguration config;
     private final ProcessPaths paths;
@@ -166,8 +165,18 @@ public class SubstrateDispatcher {
         this.buildRoot = Objects.requireNonNull(buildRoot);
         this.config = Objects.requireNonNull(config);
         this.paths = new ProcessPaths(buildRoot, config.getTargetTriplet().getArchOs());
-        this.targetConfiguration = Objects.requireNonNull(config.getTargetTriplet().getConfiguration(paths, config),
+        this.targetConfiguration = Objects.requireNonNull(getTargetConfiguration(config.getTargetTriplet()),
                 "Error: Target Configuration was null");
+    }
+    private TargetConfiguration getTargetConfiguration( Triplet targetTriplet ) {
+        switch (targetTriplet.getOs()) {
+            case Constants.OS_LINUX : return new LinuxTargetConfiguration(paths, config);
+            case Constants.OS_DARWIN: return new DarwinTargetConfiguration(paths, config);
+            case Constants.OS_WINDOWS: return new WindowsTargetConfiguration(paths, config);
+            case Constants.OS_IOS: return new IosTargetConfiguration(paths, config);
+            case Constants.OS_ANDROID: return new AndroidTargetConfiguration(paths, config);
+            default: return null;
+        }
     }
 
 

--- a/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
+++ b/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
@@ -150,7 +150,6 @@ public class SubstrateDispatcher {
         System.err.println("Usage:\n java -Dimagecp=... -Dgraalvm=... -Dmainclass=... com.gluonhq.substrate.SubstrateDispatcher");
     }
 
-    private final Path buildRoot;
     private final ProjectConfiguration config;
     private final ProcessPaths paths;
     private final TargetConfiguration targetConfiguration;
@@ -162,9 +161,8 @@ public class SubstrateDispatcher {
      * @param config the ProjectConfiguration, including the target triplet
      */
     public SubstrateDispatcher(Path buildRoot, ProjectConfiguration config) throws IOException {
-        this.buildRoot = Objects.requireNonNull(buildRoot);
         this.config = Objects.requireNonNull(config);
-        this.paths = new ProcessPaths(buildRoot, config.getTargetTriplet().getArchOs());
+        this.paths = new ProcessPaths(Objects.requireNonNull(buildRoot), config.getTargetTriplet().getArchOs());
         this.targetConfiguration = Objects.requireNonNull(getTargetConfiguration(config.getTargetTriplet()),
                 "Error: Target Configuration was null");
     }

--- a/src/main/java/com/gluonhq/substrate/model/Triplet.java
+++ b/src/main/java/com/gluonhq/substrate/model/Triplet.java
@@ -102,13 +102,13 @@ public class Triplet {
         }
     }
 
-    public TargetConfiguration getConfiguration() {
+    public TargetConfiguration getConfiguration(ProcessPaths paths, ProjectConfiguration configuration) {
         switch (getOs()) {
-            case Constants.OS_LINUX : return new LinuxTargetConfiguration();
-            case Constants.OS_DARWIN: return new DarwinTargetConfiguration();
-            case Constants.OS_WINDOWS: return new WindowsTargetConfiguration();
-            case Constants.OS_IOS: return new IosTargetConfiguration();
-            case Constants.OS_ANDROID: return new AndroidTargetConfiguration();
+            case Constants.OS_LINUX : return new LinuxTargetConfiguration(paths, configuration);
+            case Constants.OS_DARWIN: return new DarwinTargetConfiguration(paths, configuration);
+            case Constants.OS_WINDOWS: return new WindowsTargetConfiguration(paths, configuration);
+            case Constants.OS_IOS: return new IosTargetConfiguration(paths, configuration);
+            case Constants.OS_ANDROID: return new AndroidTargetConfiguration(paths, configuration);
             default: return null;
         }
     }

--- a/src/main/java/com/gluonhq/substrate/model/Triplet.java
+++ b/src/main/java/com/gluonhq/substrate/model/Triplet.java
@@ -102,18 +102,6 @@ public class Triplet {
         }
     }
 
-    public TargetConfiguration getConfiguration(ProcessPaths paths, ProjectConfiguration configuration) {
-        switch (getOs()) {
-            case Constants.OS_LINUX : return new LinuxTargetConfiguration(paths, configuration);
-            case Constants.OS_DARWIN: return new DarwinTargetConfiguration(paths, configuration);
-            case Constants.OS_WINDOWS: return new WindowsTargetConfiguration(paths, configuration);
-            case Constants.OS_IOS: return new IosTargetConfiguration(paths, configuration);
-            case Constants.OS_ANDROID: return new AndroidTargetConfiguration(paths, configuration);
-            default: return null;
-        }
-    }
-
-
     /*
      * check if this host can be used to provide binaries for this target.
      * host and target should not be null.

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -134,8 +134,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         String extraMessage = null;
         if (!failure) {
             String nameSearch = mainClassName.toLowerCase() + "." + getObjectFileExtension();
-            Path p = FileOps.findFile(gvmPath, nameSearch);
-            if (p == null) {
+            if (FileOps.findFile(gvmPath, nameSearch).isEmpty()) {
                 failure = true;
                 extraMessage = "Objectfile should be called "+nameSearch+" but we didn't find that under "+gvmPath.toString();
             }
@@ -187,11 +186,10 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         String appName = projectConfiguration.getAppName();
         String objectFilename = projectConfiguration.getMainClassName().toLowerCase() + "." + getObjectFileExtension();
         Path gvmPath = paths.getGvmPath();
-        Path objectFile = FileOps.findFile(gvmPath, objectFilename);
-        if (objectFile == null) {
-            throw new IllegalArgumentException("Linking failed, since there is no objectfile named "+objectFilename+" under "
-                    +gvmPath.toString());
-        }
+        Path objectFile = FileOps.findFile(gvmPath, objectFilename).orElseThrow( () ->
+            new IllegalArgumentException(
+                    "Linking failed, since there is no objectfile named " + objectFilename + " under " + gvmPath.toString())
+        );
 
         ProcessBuilder linkBuilder = new ProcessBuilder(getLinker());
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -57,23 +57,29 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractTargetConfiguration implements TargetConfiguration {
 
-    ProjectConfiguration projectConfiguration;
-    ProcessPaths paths;
+    final FileDeps fileDeps;
+    final ProjectConfiguration projectConfiguration;
+    final ProcessPaths paths;
 
     private List<String> attachList = Collections.emptyList();
     private List<String> defaultAdditionalSourceFiles = Collections.singletonList("launcher.c");
     private boolean useGlisten = false;
+
+    public AbstractTargetConfiguration( ProcessPaths paths, ProjectConfiguration configuration ) {
+        this.projectConfiguration = configuration;
+        this.fileDeps = new FileDeps(configuration);
+        this.paths = paths;
+    }
+
 
     String processClassPath(String cp) throws IOException {
         return cp;
     }
 
     @Override
-    public boolean compile(ProcessPaths paths, ProjectConfiguration config, String cp) throws IOException, InterruptedException {
-        this.projectConfiguration = config;
-        this.paths = paths;
+    public boolean compile(String cp) throws IOException, InterruptedException {
         String classPath = processClassPath(cp);
-        Triplet target =  config.getTargetTriplet();
+        Triplet target =  projectConfiguration.getTargetTriplet();
         String suffix = target.getArchOs();
         String jniPlatform = getJniPlatform(target.getOs());
         if (!compileAdditionalSources()) {
@@ -82,7 +88,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         Path gvmPath = paths.getGvmPath();
         FileOps.rmdir(paths.getTmpPath());
         String tmpDir = paths.getTmpPath().toFile().getAbsolutePath();
-        String mainClassName = config.getMainClassName();
+        String mainClassName = projectConfiguration.getMainClassName();
         if (mainClassName == null || mainClassName.isEmpty()) {
             throw new IllegalArgumentException("No main class is supplied. Cannot compile.");
         }
@@ -91,7 +97,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         attachList = AttachResolver.attachServices(cp);
         useGlisten = GlistenResolver.useGlisten(cp);
-        String nativeImage = getNativeImagePath(config);
+        String nativeImage = getNativeImagePath();
         ProcessBuilder compileBuilder = new ProcessBuilder(nativeImage);
         compileBuilder.command().add("--report-unsupported-elements-at-runtime");
         compileBuilder.command().add("-Djdk.internal.lambda.eagerlyInitialize=false");
@@ -163,22 +169,20 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
      * The clibraries path is available by default in GraalVM, but the directory for cross-platform libs may
      * not exist. In that case, retrieve the libs from our download site.
      */
-    private void ensureClibs (ProjectConfiguration projectConfiguration) throws IOException {
+    private void ensureClibs() throws IOException {
         Triplet target = projectConfiguration.getTargetTriplet();
         Path clibPath = Path.of(projectConfiguration.getGraalPath(), "lib", "svm", "clibraries", target.getOsArch2());
         if (!Files.exists(clibPath)) {
             String url = URL_CLIBS_ZIP.replace("${osarch}", target.getOsArch());
-            FileDeps.downloadZip(url, clibPath);
+            fileDeps.downloadZip(url, clibPath);
         }
         if (!Files.exists(clibPath)) throw new IOException("No clibraries found for the required architecture in "+clibPath);
     }
 
     @Override
-    public boolean link(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
-        this.paths = paths;
-        this.projectConfiguration = projectConfiguration;
+    public boolean link() throws IOException, InterruptedException {
 
-        ensureClibs(projectConfiguration);
+        ensureClibs();
 
         String appName = projectConfiguration.getAppName();
         String objectFilename = projectConfiguration.getMainClassName().toLowerCase() + "." + getObjectFileExtension();
@@ -231,12 +235,12 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     }
 
     private void addJavaStaticLibsPathToLinkProcess(ProcessBuilder linkBuilder) throws IOException {
-        Path javaSDKPath = FileDeps.getJavaSDKPath(projectConfiguration);
+        Path javaSDKPath = fileDeps.getJavaSDKPath();
         linkBuilder.command().add(getLinkLibraryPathOption() + javaSDKPath);
     }
 
     private void addJavaFXStaticLibsPathToLinkProcess(ProcessBuilder linkBuilder) throws IOException {
-        Path javafxSDKPath = FileDeps.getJavaFXSDKLibsPath(projectConfiguration);
+        Path javafxSDKPath = fileDeps.getJavaFXSDKLibsPath();
         linkBuilder.command().add(getLinkLibraryPathOption() + javafxSDKPath);
     }
 
@@ -260,8 +264,8 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
     }
 
-    private String getNativeImagePath(ProjectConfiguration configuration) {
-        String graalPath = configuration.getGraalPath();
+    private String getNativeImagePath() {
+        String graalPath = projectConfiguration.getGraalPath();
         Path path = Path.of(graalPath, "bin", getNativeImageCommand());
         return path.toString();
     }
@@ -327,7 +331,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     }
 
     @Override
-    public boolean runUntilEnd(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
+    public boolean runUntilEnd() throws IOException, InterruptedException {
         Process runProcess = startAppProcess(paths.getAppPath(), projectConfiguration.getAppName());
         InputStream is = runProcess.getInputStream();
         asynPrintFromInputStream(is);
@@ -359,7 +363,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             }
         }
         // there is no pre-configured llc, search it in the cache, or populare the cache
-        Path llcPath = FileDeps.getLlcPath(projectConfiguration);
+        Path llcPath = fileDeps.getLlcPath();
         return llcPath;
     }
 
@@ -429,11 +433,8 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         Path gvmPath = paths.getGvmPath();
         Path reflectionPath = gvmPath.resolve(Constants.REFLECTION_ARCH_FILE
                 .replace("${archOs}", suffix));
-        File f = reflectionPath.toFile();
-        if (f.exists()) {
-            f.delete();
-        }
-        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(f)))) {
+        Files.deleteIfExists(reflectionPath);
+        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(reflectionPath.toFile())))) {
             bw.write("[\n");
             writeSingleEntry(bw, projectConfiguration.getMainClassName(), false);
             for (String javaFile : getReflectionClassList(suffix, projectConfiguration.isUseJavaFX(), projectConfiguration.isUsePrismSW())) {

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -51,8 +51,8 @@ public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
     private final Path ldlld;
     private final Path clang;
 
-    private List<String> androidAdditionalSourceFiles = Arrays.asList("launcher.c");
-    private List<String> androidAdditionalHeaderFiles = Arrays.asList("grandroid.h");
+    private List<String> androidAdditionalSourceFiles = Collections.singletonList("launcher.c");
+    private List<String> androidAdditionalHeaderFiles = Collections.singletonList("grandroid.h");
     private List<String> cFlags = Arrays.asList("-target", "aarch64-linux-android", "-I.");
     private List<String> linkFlags = Arrays.asList("-target", "aarch64-linux-android21", "-fPIC", "-Wl,--gc-sections",
             "-landroid", "-llog", "-shared");
@@ -60,7 +60,9 @@ public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
             "-lprism_es2_monocle", "-lglass_monocle", "-ljavafx_font_freetype", "-Wl,--no-whole-archive",
             "-lGLESv2", "-lEGL", "-lfreetype");
 
-    public AndroidTargetConfiguration() {
+
+    public AndroidTargetConfiguration( ProcessPaths paths, ProjectConfiguration configuration ) {
+        super(paths,configuration);
         // for now, we need to have an ANDROID_NDK
         // we will fail fast whenever a method is invoked that uses it (e.g. compile)
         String sysndk = System.getenv("ANDROID_NDK");
@@ -96,7 +98,7 @@ public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
         if (!projectConfiguration.isUseJavaFX()) {
             return classPath;
         }
-        Path javafxSDKLibsPath = FileDeps.getJavaFXSDKLibsPath(projectConfiguration);
+        Path javafxSDKLibsPath = fileDeps.getJavaFXSDKLibsPath();
         return Stream.of(classPath.split(File.pathSeparator))
                 .map(s -> {
                     if (s.indexOf("javafx-graphics") > 0) {
@@ -111,20 +113,20 @@ public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
-    public boolean compile(ProcessPaths paths, ProjectConfiguration config, String classPath) throws IOException, InterruptedException {
+    public boolean compile(String classPath) throws IOException, InterruptedException {
         // we override compile as we need to do some checks first. If we have no ld.lld in android_ndk, we should not start compiling
         if (ndk == null) throw new IOException ("Can't find an Android NDK on your system. Set the environment property ANDROID_NDK");
         if (ldlld == null) throw new IOException ("You specified an android ndk, but it doesn't contain "+ndk+"/toolchains/llvm/prebuilt/linux-x86_64/bin/ldlld");
         if (clang == null) throw new IOException ("You specified an android ndk, but it doesn't contain "+ndk+"/toolchains/llvm/prebuilt/linux-x86_64/bin/clang");
-        return super.compile(paths, config, classPath);
+        return super.compile(classPath);
     }
 
     @Override
-    public boolean link(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
+    public boolean link() throws IOException, InterruptedException {
         // we override compile as we need to do some checks first. If we have no clang in android_ndk, we should not start linking
         if (ndk == null) throw new IOException ("Can't find an Android NDK on your system. Set the environment property ANDROID_NDK");
         if (clang == null) throw new IOException ("You specified an android ndk, but it doesn't contain "+ndk+"/toolchains/llvm/prebuilt/linux-x86_64/bin/clang");
-        return super.link(paths, projectConfiguration);
+        return super.link();
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -142,9 +142,9 @@ public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
 
     @Override
     List<String> getTargetSpecificObjectFiles() throws IOException {
-        Path gvmPath = paths.getGvmPath();
-        Path objectFile = FileOps.findFile(gvmPath, "llvm.o");
-        return Collections.singletonList(objectFile.toAbsolutePath().toString());
+       return FileOps.findFile( paths.getGvmPath(), "llvm.o").map( objectFile ->
+           Collections.singletonList(objectFile.toAbsolutePath().toString())
+       ).orElseThrow();
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
@@ -27,6 +27,9 @@
  */
 package com.gluonhq.substrate.target;
 
+import com.gluonhq.substrate.model.ProcessPaths;
+import com.gluonhq.substrate.model.ProjectConfiguration;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +40,10 @@ public class DarwinTargetConfiguration extends AbstractTargetConfiguration {
     private static final List<String> darwinLibs = Arrays.asList(
             "-llibchelper", "-lpthread",
             "-Wl,-framework,Foundation", "-Wl,-framework,AppKit");
+
+    public DarwinTargetConfiguration(ProcessPaths paths, ProjectConfiguration configuration ) {
+        super(paths, configuration);
+    }
 
     @Override
     String getAdditionalSourceFileLocation() {

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -125,9 +125,9 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
 
     @Override
     List<String> getTargetSpecificObjectFiles() throws IOException {
-        Path gvmPath = paths.getGvmPath();
-        Path objectFile = FileOps.findFile(gvmPath, "llvm.o");
-        return Collections.singletonList(objectFile.toAbsolutePath().toString());
+        return FileOps.findFile( paths.getGvmPath(), "llvm.o").map( objectFile ->
+           Collections.singletonList(objectFile.toAbsolutePath().toString())
+        ).orElseThrow();
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -67,6 +67,10 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
             "-Wl,-framework,OpenGLES", "-Wl,-framework,CoreText",
             "-Wl,-framework,QuartzCore", "-Wl,-framework,ImageIO");
 
+    public IosTargetConfiguration(ProcessPaths paths, ProjectConfiguration configuration ) {
+        super(paths, configuration);
+    }
+
     @Override
     List<String> getTargetSpecificLinkLibraries() {
         List<String> defaultLinkFlags = new ArrayList<>(super.getTargetSpecificLinkLibraries());
@@ -132,8 +136,8 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
-    public boolean link(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
-        boolean result = super.link(paths, projectConfiguration);
+    public boolean link() throws IOException, InterruptedException {
+        boolean result = super.link();
 
         if (result) {
             createInfoPlist(paths, projectConfiguration);
@@ -149,9 +153,7 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
-    public boolean runUntilEnd(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
-        this.paths = paths;
-        this.projectConfiguration = projectConfiguration;
+    public boolean runUntilEnd() throws IOException, InterruptedException {
         Deploy.addDebugSymbolInfo(paths.getAppPath(), projectConfiguration.getAppName());
         String appPath = paths.getAppPath().resolve(projectConfiguration.getAppName() + ".app").toString();
         if (isSimulator()) {
@@ -196,7 +198,7 @@ public class IosTargetConfiguration extends AbstractTargetConfiguration {
         if (!projectConfiguration.isUseJavaFX()) {
             return classPath;
         }
-        Path javafxSDKLibsPath = FileDeps.getJavaFXSDKLibsPath(projectConfiguration);
+        Path javafxSDKLibsPath = fileDeps.getJavaFXSDKLibsPath();
         return Stream.of(classPath.split(File.pathSeparator))
                 .map(s -> {
                     if (s.indexOf("javafx-graphics") > 0) {

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -48,11 +48,15 @@ public class LinuxTargetConfiguration extends AbstractTargetConfiguration {
     private static final Version COMPILER_MINIMAL_VERSION = new Version(6);
     private static final Version LINKER_MINIMAL_VERSION = new Version(2, 26);
 
+    public LinuxTargetConfiguration( ProcessPaths paths, ProjectConfiguration configuration ) {
+        super(paths, configuration);
+    }
+
     @Override
-    public boolean link(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException {
+    public boolean link() throws IOException, InterruptedException {
         checkCompiler();
         checkLinker();
-        return super.link(paths, projectConfiguration);
+        return super.link();
     }
 
     private static final List<String> linuxLibs = Arrays.asList("-llibchelper", "-lpthread");

--- a/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
@@ -37,17 +37,15 @@ public interface TargetConfiguration {
 
     /**
      * Compiles the classes to objectcode for this TargetConfiguration.
-     * @param paths
-     * @param config
      * @param classPath
      * @return true if compilation succeeded, false if it failed
      * @throws Exception
      */
-    boolean compile(ProcessPaths paths, ProjectConfiguration config, String classPath) throws Exception;
+    boolean compile(String classPath) throws Exception;
 
-    boolean link(ProcessPaths paths, ProjectConfiguration config) throws IOException, InterruptedException;
+    boolean link() throws IOException, InterruptedException;
 
-    boolean runUntilEnd(ProcessPaths paths, ProjectConfiguration projectConfiguration) throws IOException, InterruptedException;
+    boolean runUntilEnd() throws IOException, InterruptedException;
 
     /**
      * Runs the application at the given path, and if successful, returns the last line

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -27,10 +27,19 @@
  */
 package com.gluonhq.substrate.target;
 
+import com.gluonhq.substrate.model.ProcessPaths;
+import com.gluonhq.substrate.model.ProjectConfiguration;
+
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
+
+
+    public WindowsTargetConfiguration(ProcessPaths paths, ProjectConfiguration configuration ) {
+        super(paths, configuration);
+    }
 
     @Override
     String getAdditionalSourceFileLocation() {
@@ -39,12 +48,12 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
 
     @Override
     List<String> getAdditionalSourceFiles() {
-        return Arrays.asList("launcher.c");
+        return Collections.singletonList("launcher.c");
     }
 
     @Override
     List<String> getTargetSpecificCCompileFlags() {
-        return Arrays.asList("/MT");
+        return Collections.singletonList("/MT");
     }
 
     @Override
@@ -70,7 +79,7 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     @Override
     List<String> getTargetSpecificLinkOutputFlags() {
         String appName = projectConfiguration.getAppName();
-        return Arrays.asList("/OUT:" + getAppPath(appName + ".exe"));
+        return Collections.singletonList("/OUT:" + getAppPath(appName + ".exe"));
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -36,7 +36,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.URL;
 import java.nio.channels.Channels;
@@ -46,9 +45,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +55,7 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-public class FileDeps {
+public final class FileDeps {
 
     private static final String URL_GRAAL_LIBS = "http://download2.gluonhq.com/omega/graallibs/graalvm-svm-${host}-${version}.zip";
     private static final String JAVA_STATIC_ZIP = "labs-staticjdk-${target}-gvm-${version}.zip";
@@ -78,49 +74,48 @@ public class FileDeps {
             "libglass.a"
     );
 
-    /**
-     * Return the path to the JavaFX SDK for this configuration.
-     * The path is cached on the provided configuration.
-     * If it is not there yet, all dependencies are retrieved.
-     * @param configuration the project configuration
-     * @return the location of the JavaFX SDK for the arch-os for this configuration
-     * @throws IOException in case anything goes wrong.
-     */
-    public static Path getJavaSDKPath(ProjectConfiguration configuration) throws IOException {
-        return resolvePath(configuration,
-                configuration.getJavaStaticLibsPath(),
-                "Fatal error, could not install Java SDK ");
+    private final ProjectConfiguration configuration;
+
+    public FileDeps( ProjectConfiguration config ) {
+        this.configuration = Objects.requireNonNull(config);
     }
 
     /**
      * Return the path to the JavaFX SDK for this configuration.
      * The path is cached on the provided configuration.
      * If it is not there yet, all dependencies are retrieved.
-     * @param configuration the project configuration
      * @return the location of the JavaFX SDK for the arch-os for this configuration
      * @throws IOException in case anything goes wrong.
      */
-    public static Path getJavaFXSDKLibsPath(ProjectConfiguration configuration) throws IOException {
-        return resolvePath(configuration,
-                configuration.getJavafxStaticLibsPath(),
-                "Fatal error, could not install JavaFX SDK ");
+    public Path getJavaSDKPath() throws IOException {
+        return resolvePath( configuration.getJavaStaticLibsPath(),"Fatal error, could not install Java SDK ");
+    }
+
+    /**
+     * Return the path to the JavaFX SDK for this configuration.
+     * The path is cached on the provided configuration.
+     * If it is not there yet, all dependencies are retrieved.
+     * @return the location of the JavaFX SDK for the arch-os for this configuration
+     * @throws IOException in case anything goes wrong.
+     */
+    public Path getJavaFXSDKLibsPath() throws IOException {
+        return resolvePath( configuration.getJavafxStaticLibsPath(),"Fatal error, could not install JavaFX SDK ");
     }
 
     /**
      * For a given path, it verifies that the path exists, or else it tries
      * to install it. After that, it returns the path for this configuration.
-     * @param configuration the project configuration
      * @param path the initial path
      * @param errorMessage a message that will be displayed in case of error
      * @return the location of the path for this configuration
      * @throws IOException in case anything goes wrong.
      */
-    private static Path resolvePath(ProjectConfiguration configuration, Path path, String errorMessage) throws IOException {
+    private Path resolvePath(Path path, String errorMessage) throws IOException {
         if (Files.exists(Objects.requireNonNull(path))) {
             return path;
         }
-        if (!setupDependencies(Objects.requireNonNull(configuration))) {
-            throw new IOException("Error setting up dependencies");
+        if (!setupDependencies()) {
+            throw new IOException(errorMessage); //"Error setting up dependencies"
         }
         return path;
     }
@@ -139,11 +134,10 @@ public class FileDeps {
      * the default location, and contain an unmodified set of files.
      * If this is not the case, the correct SDK is downloaded and unzipped.
      *
-     * @param configuration Project configuration with the paths of the static SDKs
      * @return true if the processed ended succesfully, false otherwise
      * @throws IOException in case default path for Substrate dependencies can't be created
      */
-    private static boolean setupDependencies(ProjectConfiguration configuration) throws IOException {
+    private boolean setupDependencies() throws IOException {
         String target = configuration.getTargetTriplet().getOsArch();
 
         if (!Files.isDirectory(Constants.USER_SUBSTRATE_PATH)) {
@@ -183,13 +177,13 @@ public class FileDeps {
                     // when the directory for the libs is found, and it is not a user-supplied one, check for its validity
                     Logger.logDebug("Checking java static sdk hashes");
                     String md5File = getChecksumFile(defaultJavaStaticPath, "javaStaticSdk", target);
-                    Map<String, String> hashes = getHashMap(md5File);
+                    Map<String, String> hashes = FileOps.getHashMap(md5File);
                     if (hashes == null) {
                         Logger.logDebug(md5File+" not found");
                         downloadJavaStatic = true;
                     } else if (JAVA_FILES.stream()
                             .map(s -> new File(path, s))
-                            .anyMatch(f -> !hashes.get(f.getName()).equals(calculateCheckSum(f)))) {
+                            .anyMatch(f -> !hashes.get(f.getName()).equals(FileOps.calculateCheckSum(f)))) {
                         Logger.logDebug("jar file has invalid hashcode");
                         downloadJavaStatic = true;
                     }
@@ -215,13 +209,13 @@ public class FileDeps {
                 } else if (configuration.isEnableCheckHash()) {
                     Logger.logDebug("Checking javafx static sdk hashes");
                     String md5File = getChecksumFile(javafxStatic.getParent(), "javafxStaticSdk", target);
-                    Map<String, String> hashes = getHashMap(md5File);
+                    Map<String, String> hashes = FileOps.getHashMap(md5File);
                     if (hashes == null) {
                         Logger.logDebug(md5File + " md5 not found");
                         downloadJavaFXStatic = true;
                     } else if (JAVAFX_FILES.stream()
                             .map(s -> new File(path, s))
-                            .anyMatch(f -> !hashes.get(f.getName()).equals(calculateCheckSum(f)))) {
+                            .anyMatch(f -> !hashes.get(f.getName()).equals(FileOps.calculateCheckSum(f)))) {
                         Logger.logDebug("jar file has invalid hashcode");
                         downloadJavaFXStatic = true;
                     }
@@ -234,11 +228,11 @@ public class FileDeps {
 //            }
 
             if (downloadJavaStatic) {
-                downloadJavaZip(target, Constants.USER_SUBSTRATE_PATH, configuration);
+                downloadJavaZip(target, Constants.USER_SUBSTRATE_PATH);
             }
 
             if (downloadJavaFXStatic) {
-                downloadJavaFXZip(target, Constants.USER_SUBSTRATE_PATH, configuration);
+                downloadJavaFXZip(target, Constants.USER_SUBSTRATE_PATH);
             }
 
         } catch (IOException e) {
@@ -268,11 +262,10 @@ public class FileDeps {
      *     Substrate. If the developer wants a specific flavour of llc, it is recommended to
      *     use <code>configuration.setLlcPath()</code> which takes precedence over calling this method.
      * </p>
-     * @param configuration
      * @return the path to a working llc compiler.
      * @throws IOException in case the required directories can't be created or navigated into.
      */
-    public static Path getLlcPath(ProjectConfiguration configuration) throws IOException {
+    public Path getLlcPath() throws IOException {
         Path llcRootPath = Constants.USER_SUBSTRATE_PATH.resolve(Constants.LLC_NAME);
         String archos = configuration.getHostTriplet().getArchOs();
         Path archosPath = llcRootPath.resolve(archos).resolve(Constants.LLC_VERSION);
@@ -291,9 +284,9 @@ public class FileDeps {
              FileOutputStream fileOutputStream = new FileOutputStream(llcPath.toFile());
              FileChannel fileChannel = fileOutputStream.getChannel()) {
             fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
-            readableByteChannel.close();
+            //readableByteChannel.close();
         } catch (IOException e) {
-            throw new IOException("Error downloading LLC from " + url + ": " + e.getMessage() + ", " + e.getSuppressed());
+            throw new IOException("Error downloading LLC from " + url + ": " + e.getMessage() + ", " + Arrays.toString(e.getSuppressed()));
         }
         Set<PosixFilePermission> perms = new HashSet<>();
         perms.add(PosixFilePermission.OWNER_READ);
@@ -303,52 +296,29 @@ public class FileDeps {
         return llcPath;
     }
 
-    /**
-     * Return the hashmap associated with this nameFile.
-     * If a file named <code>nameFile</code> exists, and it contains  a serialized version of a Map, this
-     * Map will be returned.
-     * If the file doesn't exist or is corrupt, this method returns null
-     * @param nameFile
-     * @return the Map contained in the file named nameFile, or null in all other cases.
-     */
-    private static Map<String, String> getHashMap(String nameFile) {
-        Map<String, String> hashes = null;
-        if (!Files.exists(Paths.get(nameFile))) {
-            return null;
-        }
-        try (FileInputStream fis = new FileInputStream(new File(nameFile));
-             ObjectInputStream ois = new ObjectInputStream(fis)) {
-            hashes = (Map<String, String>) ois.readObject();
-        } catch (IOException | ClassNotFoundException e) {
-            Logger.logDebug("Exception trying to get hashmap for "+nameFile+": "+e);
-            return null;
-        }
-        return hashes;
-    }
-
     private static String getChecksumFile(Path unpacked, String name, String osArch) {
         return unpacked.getParent().resolve( String.format("%s-%s.md5", name, osArch) ).toString();
     }
 
-    private static void downloadJavaZip(String target, Path substratePath, ProjectConfiguration configuration) throws IOException {
+    private void downloadJavaZip(String target, Path substratePath) throws IOException {
         Logger.logDebug("Process zip javaStaticSdk, target = "+target);
         String javaZip = JAVA_STATIC_ZIP
                 .replace("${version}", configuration.getJavaStaticSdkVersion())
                 .replace("${target}", target);
         processZip(JAVA_STATIC_URL + javaZip,
                 substratePath.resolve(javaZip),
-                "javaStaticSdk", configuration.getJavaStaticSdkVersion(), configuration);
+                "javaStaticSdk", configuration.getJavaStaticSdkVersion());
         Logger.logDebug("Processing zip java done");
     }
 
-    private static void downloadJavaFXZip(String osarch, Path substratePath, ProjectConfiguration configuration) throws IOException {
+    private void downloadJavaFXZip(String osarch, Path substratePath ) throws IOException {
         Logger.logDebug("Process zip javafxStaticSdk");
         String javafxZip = JAVAFX_STATIC_ZIP
                 .replace("${version}", configuration.getJavafxStaticSdkVersion())
                 .replace("${target}", osarch);
         processZip(JAVAFX_STATIC_URL + javafxZip,
                 substratePath.resolve(javafxZip),
-                "javafxStaticSdk", configuration.getJavafxStaticSdkVersion(), configuration);
+                "javafxStaticSdk", configuration.getJavafxStaticSdkVersion());
 
         Logger.logDebug("Process zip javafx done");
     }
@@ -364,16 +334,16 @@ public class FileDeps {
      *                    The contents of this zip file will be installed in graalvm/libs/clibraries/foo
      * @throws IOException
      */
-    public static void downloadZip(String urlZip, Path destination) throws IOException {
+    public void downloadZip(String urlZip, Path destination) throws IOException {
         String zip = destination.toAbsolutePath().toString()+".zip";
         Path zipPath = Paths.get(zip);
-        processZip(urlZip, zipPath, destination.getFileName().toString(), null, null);
+        processZip(urlZip, zipPath, destination.getFileName().toString(), null);
     }
 
-    private static void processZip(String urlZip, Path zipPath, String folder, String version, ProjectConfiguration configuration) throws IOException {
+    private void processZip(String urlZip, Path zipPath, String folder, String version) throws IOException {
         String osArch = configuration == null? null : configuration.getTargetTriplet().getOsArch();
         String md5name = osArch == null? folder+".md5" : folder+"-"+osArch+".md5";
-        System.err.println("PROCESSZIP, url = "+urlZip+", zp = "+zipPath+", folder = "+folder+", version = "+version+", name = "+md5name);
+        System.err.println("PROCESS ZIP, url = "+urlZip+", zp = "+zipPath+", folder = "+folder+", version = "+version+", name = "+md5name);
         URL url = new URL(urlZip);
         url.openConnection();
         try (InputStream reader = url.openStream();
@@ -411,7 +381,7 @@ public class FileDeps {
                             fos.write(buffer, 0, len);
                         }
                     }
-                    String sum = calculateCheckSum(destFile);
+                    String sum = FileOps.calculateCheckSum(destFile);
                     hashes.put(destFile.getName(), sum);
                 }
                 zipEntry = zis.getNextEntry();
@@ -423,23 +393,6 @@ public class FileDeps {
                       new FileOutputStream(zipDir.toString() + File.separator + md5name);
              ObjectOutputStream oos = new ObjectOutputStream(fos)) {
             oos.writeObject(hashes);
-        }
-    }
-
-    private static String calculateCheckSum(File file) {
-        try {
-            // not looking for security, just a checksum. MD5 should be faster than SHA
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
-            try (final InputStream stream = new FileInputStream(file);
-                 final DigestInputStream dis = new DigestInputStream(stream, md5)) {
-                md5.reset();
-                byte[] buffer = new byte[4096];
-                while (dis.read(buffer) != -1) { /* empty loop body is intentional */ }
-                return Arrays.toString(md5.digest());
-            }
-
-        } catch (IllegalArgumentException | NoSuchAlgorithmException | IOException | SecurityException e) {
-            return "";
         }
     }
 

--- a/src/main/java/com/gluonhq/substrate/util/FileDeps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileDeps.java
@@ -121,7 +121,6 @@ public final class FileDeps {
     }
 
     /**
-     *
      * First, this method searches for a valid location of the java static libraries
      * (e.g. libjava.a). When a user-supplied location is present, this location will be
      * used to check for the presence of those libraries. If the user-supplied location is
@@ -176,7 +175,7 @@ public final class FileDeps {
                 } else if (!customJavaLocation && configuration.isEnableCheckHash()) {
                     // when the directory for the libs is found, and it is not a user-supplied one, check for its validity
                     Logger.logDebug("Checking java static sdk hashes");
-                    String md5File = getChecksumFile(defaultJavaStaticPath, "javaStaticSdk", target);
+                    String md5File = getChecksumFileName(defaultJavaStaticPath, "javaStaticSdk", target);
                     Map<String, String> hashes = FileOps.getHashMap(md5File);
                     if (hashes == null) {
                         Logger.logDebug(md5File+" not found");
@@ -208,7 +207,7 @@ public final class FileDeps {
                     downloadJavaFXStatic = true;
                 } else if (configuration.isEnableCheckHash()) {
                     Logger.logDebug("Checking javafx static sdk hashes");
-                    String md5File = getChecksumFile(javafxStatic.getParent(), "javafxStaticSdk", target);
+                    String md5File = getChecksumFileName(javafxStatic.getParent(), "javafxStaticSdk", target);
                     Map<String, String> hashes = FileOps.getHashMap(md5File);
                     if (hashes == null) {
                         Logger.logDebug(md5File + " md5 not found");
@@ -296,8 +295,15 @@ public final class FileDeps {
         return llcPath;
     }
 
-    private static String getChecksumFile(Path unpacked, String name, String osArch) {
-        return unpacked.getParent().resolve( String.format("%s-%s.md5", name, osArch) ).toString();
+    /**
+     * Generates standardized checksum file name for a given os architecture
+     * @param base base path, parent of which will be used
+     * @param customPart custom part of the name
+     * @param osArch os architecture
+     * @return
+     */
+    private static String getChecksumFileName(Path base, String customPart, String osArch) {
+        return base.getParent().resolve( String.format("%s-%s.md5", customPart, osArch) ).toString();
     }
 
     private void downloadJavaZip(String target, Path substratePath) throws IOException {

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -53,18 +53,17 @@ public class FileOps {
      * Find the file with the provided name in the provided directory.
      * @param workDir
      * @param name
-     * @return the path to the file, or <code>null</code> if no such file is found
+     * @return Optional path of the file
      * @throws IOException
      */
-    public static Path findFile(Path workDir, String name) throws IOException {
-        List<Path> answers = new LinkedList<>();
-        Optional<Path> objectPath;
+    public static Optional<Path> findFile(Path workDir, String name) throws IOException {
+        Path[] paths = {null};
         SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 Path fileName = file.getFileName();
                 if (fileName != null && fileName.toString().endsWith(name)) {
-                    answers.add(file);
+                    paths[0] = file;
                     return FileVisitResult.TERMINATE;
                 }
                 return FileVisitResult.CONTINUE;
@@ -77,8 +76,7 @@ public class FileOps {
         };
 
         Files.walkFileTree(workDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, visitor);
-        if (answers.size() < 1) return null;
-        return answers.get(0);
+        return Optional.ofNullable(paths[0]);
     }
 
     /**

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -256,7 +256,13 @@ public class FileOps {
         return hashes;
     }
 
-    static String calculateCheckSum(File file) {
+    /**
+     * Calculates checksum of the file content.
+     * Currently uses MD5 as it is faster them SHA
+     * @param file file for which checksum is calculated
+     * @return checksum as a string
+     */
+    public static String calculateCheckSum(File file) {
         try {
             // not looking for security, just a checksum. MD5 should be faster than SHA
             MessageDigest md5 = MessageDigest.getInstance("MD5");

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -94,6 +94,13 @@ public class FileOps {
                     .forEach(File::delete);
     }
 
+    /**
+     * Copies resource into destination path
+     * @param resource
+     * @param destination
+     * @return destination path
+     * @throws IOException
+     */
     public static Path copyResource(String resource, Path destination) throws IOException {
         InputStream is = resourceAsStream(resource);
         if (is == null) {
@@ -102,6 +109,13 @@ public class FileOps {
         return copyStream(is, destination);
     }
 
+    /**
+     * Copies source stream to a destination path
+     * @param sourceStream
+     * @param destination
+     * @return destination path
+     * @throws IOException
+     */
     public static Path copyStream(InputStream sourceStream, Path destination) throws IOException {
         Path parent = destination.getParent();
         if (!parent.toFile().exists()) {
@@ -119,6 +133,12 @@ public class FileOps {
         return destination;
     }
 
+    /**
+     * Represents resource as InputStream
+     * @param res resource
+     * @return InputStream representing given resource
+     * @throws IOException
+     */
     public static InputStream resourceAsStream(String res) throws IOException {
         String actualResource = Objects.requireNonNull(res).startsWith("/") ? res : "/" + res;
         Logger.logDebug("Looking for resource: " + res);
@@ -129,13 +149,24 @@ public class FileOps {
         return answer;
     }
 
+    /**
+     * Copies given resource to temp directory
+     * @param resource
+     * @return path of the copied resource
+     * @throws IOException
+     */
     public static Path copyResourceToTmp(String resource) throws IOException {
         String tmpDir = System.getProperty("java.io.tmpdir");
         Path target = Paths.get(tmpDir,resource);
         return copyResource(resource, target);
     }
 
-    // Copies source to destination, ensuring that destination exists
+    /**
+     * Copies source to destination, ensuring that destination exists
+     * @param source source path
+     * @param destination destination path
+     * @return destination path
+     */
     public static Path copyFile(Path source, Path destination)  {
         try {
             Files.createDirectories(destination.getParent());

--- a/src/test/java/com/gluonhq/substrate/SubstrateTest.java
+++ b/src/test/java/com/gluonhq/substrate/SubstrateTest.java
@@ -31,6 +31,7 @@ import com.gluonhq.substrate.model.ProjectConfiguration;
 import com.gluonhq.substrate.model.Triplet;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,7 +61,7 @@ class SubstrateTest {
     }
 
     @Test
-    void testIOSTriplet() {
+    void testIOSTriplet() throws IOException {
         Triplet iosTriplet = new Triplet(Constants.Profile.IOS);
         Triplet currentOsTriplet = Triplet.fromCurrentOS();
         ProjectConfiguration config = new ProjectConfiguration();


### PR DESCRIPTION
- `FileDeps` is used as an instance now, which simplifies its API
- File related static methods have been moved from `FileDeps` to `FileOps`
- Target Configurations, use `ProcessPaths` and `ProjectConfiguration` as constructor parameters, instead of passing them to each method
- `SubstrateDispatcher` creates and holds `ProcessPaths` and `TargetConfiguration` for use in mutiple methods, which results in simpler API
