### PR TITLE
use libnet.a from our download location

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -99,7 +99,7 @@ public class Constants {
     public static final String PROFILE_IOS_SIM = "ios-sim";
     public static final String PROFILE_ANDROID = "android";
 
-    public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "14-ea+3";
+    public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "14-ea+5";
     public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "14-ea+gvm1";
 
     /**

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -578,7 +578,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     }
 
     List<String> getTargetSpecificLinkLibraries() {
-        return Arrays.asList("-ljava", "-lnio", "-lzip", "-ljvm", "-lstrictmath", "-lz", "-ldl",
+        return Arrays.asList("-ljava", "-lnio", "-lzip", "-lnet", "-ljvm", "-lstrictmath", "-lz", "-ldl",
                 "-lj2pkcs11", "-lsunec");
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
@@ -74,9 +74,7 @@ public class DarwinTargetConfiguration extends AbstractTargetConfiguration {
     @Override
     List<String> getTargetSpecificLinkLibraries() {
         List<String> defaultLinkFlags = new ArrayList<>(super.getTargetSpecificLinkLibraries());
-        defaultLinkFlags.addAll(Arrays.asList("-Wl,-force_load," +
-                Path.of(projectConfiguration.getGraalPath(), "lib", "libnet.a").toString(),
-                "-lextnet", "-lstdc++"));
+        defaultLinkFlags.addAll(Arrays.asList("-lextnet", "-lstdc++"));
         return defaultLinkFlags;
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -37,7 +37,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -77,9 +76,7 @@ public class LinuxTargetConfiguration extends AbstractTargetConfiguration {
     @Override
     List<String> getTargetSpecificLinkLibraries() {
         List<String> defaultLinkFlags = new ArrayList<>(super.getTargetSpecificLinkLibraries());
-        defaultLinkFlags.addAll(Arrays.asList("-Wl,--whole-archive",
-                Path.of(projectConfiguration.getGraalPath(), "lib", "libnet.a").toString(),
-                "-Wl,--no-whole-archive", "-lextnet", "-lstdc++"));
+        defaultLinkFlags.addAll(Arrays.asList("-lextnet", "-lstdc++"));
         return defaultLinkFlags;
     }
 


### PR DESCRIPTION
14-ea+5 includes a workaround that allows to compile with Java 11 (instead of 14),
hence we don't need special treatment for libnet.a anymore