### PR TITLE
Add check for libjvm.a on posix platforms

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -189,7 +189,14 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             fileDeps.downloadZip(url, clibPath);
         }
         if (!Files.exists(clibPath)) throw new IOException("No clibraries found for the required architecture in "+clibPath);
+        checkPlatformSpecificClibs(clibPath);
     }
+
+    /**
+     * Allow platforms to check if specific libraries (e.g. libjvm.a) are present in the specified clib path
+     * @param clibPath
+     */
+    void checkPlatformSpecificClibs(Path clibPath) throws IOException {}
 
     private Path getCLibPath( ) {
         Triplet target = projectConfiguration.getTargetTriplet();
@@ -200,6 +207,11 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
                 .resolve(target.getOsArch2());
     }
 
+   /**
+    * Links a previously created objectfile with the required
+    * dependencies into a native executable.
+    * @return true if linking succeeded, false otherwise
+    */
     @Override
     public boolean link() throws IOException, InterruptedException {
 

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class AndroidTargetConfiguration extends AbstractTargetConfiguration {
+public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
     private final String ndk;
     private final Path ldlld;

--- a/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/DarwinTargetConfiguration.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class DarwinTargetConfiguration extends AbstractTargetConfiguration {
+public class DarwinTargetConfiguration extends PosixTargetConfiguration {
 
     private static final List<String> darwinLibs = Arrays.asList(
             "-llibchelper", "-lpthread",

--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -51,7 +51,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class IosTargetConfiguration extends AbstractTargetConfiguration {
+public class IosTargetConfiguration extends PosixTargetConfiguration {
 
     private List<String> iosAdditionalSourceFiles = Collections.singletonList("AppDelegate.m");
 

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -44,7 +44,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class LinuxTargetConfiguration extends AbstractTargetConfiguration {
+public class LinuxTargetConfiguration extends PosixTargetConfiguration {
 
     private static final Version COMPILER_MINIMAL_VERSION = new Version(6);
     private static final Version LINKER_MINIMAL_VERSION = new Version(2, 26);

--- a/src/main/java/com/gluonhq/substrate/target/PosixTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/PosixTargetConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.substrate.target;
+
+import com.gluonhq.substrate.model.InternalProjectConfiguration;
+import com.gluonhq.substrate.model.ProcessPaths;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public abstract  class PosixTargetConfiguration extends AbstractTargetConfiguration {
+
+    public PosixTargetConfiguration(ProcessPaths paths, InternalProjectConfiguration configuration ) {
+        super(paths, configuration);
+    }
+
+    void checkPlatformSpecificClibs(Path clibPath) throws IOException {
+        Path libjvmPath = clibPath.resolve("libjvm.a");
+        if (!Files.exists(libjvmPath)) throw new IOException("Missing library libjvm.a not in linkpath "+clibPath);
+
+    }
+
+}

--- a/src/main/java/com/gluonhq/substrate/target/PosixTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/PosixTargetConfiguration.java
@@ -34,16 +34,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public abstract  class PosixTargetConfiguration extends AbstractTargetConfiguration {
+public abstract class PosixTargetConfiguration extends AbstractTargetConfiguration {
 
-    public PosixTargetConfiguration(ProcessPaths paths, InternalProjectConfiguration configuration ) {
+    public PosixTargetConfiguration(ProcessPaths paths, InternalProjectConfiguration configuration) {
         super(paths, configuration);
     }
 
+    @Override
     void checkPlatformSpecificClibs(Path clibPath) throws IOException {
         Path libjvmPath = clibPath.resolve("libjvm.a");
         if (!Files.exists(libjvmPath)) throw new IOException("Missing library libjvm.a not in linkpath "+clibPath);
-
     }
 
 }


### PR DESCRIPTION
Fail fast if libjvm.a doesn't exist.

Adding an intermediate PosixTargetConfiguration file to deal with
Windows versus non-Windows operations.

This fixes #168