### PR TITLE
Wrap arguments in double quotes

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -180,6 +180,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
      * @param arguments the list of arguments of the compiler command.
      */
     void postProcessCompilerArguments(List<String> arguments) {
+        // no post processing is required by default
     }
 
     private String getJniPlatform( String os ) {

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -136,6 +136,9 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         compileBuilder.command().add(classPath);
         compileBuilder.command().addAll(projectConfiguration.getCompilerArgs());
         compileBuilder.command().add(mainClassName);
+
+        postProcessCompilerArguments(compileBuilder.command());
+
         Logger.logDebug("compile command: "+String.join(" ",compileBuilder.command()));
         Path workDir = gvmPath.resolve(projectConfiguration.getAppName());
         compileBuilder.directory(workDir.toFile());
@@ -169,6 +172,14 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     // by default, we allow the HTTPS protocol, but subclasses can decide against it.
     boolean allowHttps() {
         return true;
+    }
+
+    /**
+     * Apply post-processing to the arguments for the compiler command.
+     *
+     * @param arguments the list of arguments of the compiler command.
+     */
+    void postProcessCompilerArguments(List<String> arguments) {
     }
 
     private String getJniPlatform( String os ) {

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -61,6 +61,10 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
         return false;
     }
 
+    /**
+     * The arguments to native-image.cmd must be wrapped in double quotes when the
+     * argument contains the '=' character.
+     */
     @Override
     void postProcessCompilerArguments(List<String> arguments) {
         for (int i = 0; i < arguments.size(); i++) {

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -76,6 +76,11 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
+    String processClassPath(String cp) {
+        return "\"" + cp + "\"";
+    }
+
+    @Override
     String getCompiler() {
         return "cl";
     }

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -62,6 +62,16 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
+    void postProcessCompilerArguments(List<String> arguments) {
+        for (int i = 0; i < arguments.size(); i++) {
+            String argument = arguments.get(i);
+            if (argument.contains("=")) {
+                arguments.set(i, "\"" + argument + "\"");
+            }
+        }
+    }
+
+    @Override
     String getCompiler() {
         return "cl";
     }


### PR DESCRIPTION
On the windows target, the command line arguments for `native-image.cmd` that contain a '=' character, must be wrapped in double quotes.