### PR TITLE
Auto-close and release staging repository

### DIFF
--- a/.ci/deploy.sh
+++ b/.ci/deploy.sh
@@ -9,7 +9,7 @@ if [[ ! -s sonatype.gpg ]]
    exit 1
 fi
 
-./gradlew publish --info -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD -Psigning.keyId=$GPG_KEYNAME -Psigning.password=$GPG_PASSPHRASE -Psigning.secretKeyRingFile=sonatype.gpg
+./gradlew publish closeAndReleaseRepository -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD -Psigning.keyId=$GPG_KEYNAME -Psigning.password=$GPG_PASSPHRASE -Psigning.secretKeyRingFile=sonatype.gpg
 
 # Update version by 1
 newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'signing'
-    id "de.marcphilipp.nexus-publish" version "0.4.0"
+    id 'io.codearte.nexus-staging' version '0.21.1'
+    id 'de.marcphilipp.nexus-publish' version '0.4.0'
 }
 
 group = "com.gluonhq"
@@ -102,12 +103,12 @@ signing {
 }
 
 nexusPublishing {
-    repositories {
-        sonatype {
-            username = project.hasProperty('sonatypeUsername') ? project.property('sonatypeUsername') : ''
-            password = project.hasProperty('sonatypePassword') ? project.property('sonatypePassword') : ''
-        }
-    }
+    // credentials are shared from staging plugin
     clientTimeout = Duration.ofMinutes(5)
     connectTimeout = Duration.ofMinutes(5)
+}
+
+nexusStaging {
+    username = project.hasProperty('sonatypeUsername') ? project.property('sonatypeUsername') : ''
+    password = project.hasProperty('sonatypePassword') ? project.property('sonatypePassword') : ''
 }


### PR DESCRIPTION
Use [gradle-nexus-staging-plugin](https://github.com/Codearte/gradle-nexus-staging-plugin/) to auto-close and release the staging repository created in OSS Sonatype.