### PR TITLE
[225] multitouch events for Android

### DIFF
--- a/src/main/resources/config/jniconfig-javafx-aarch64-android.json
+++ b/src/main/resources/config/jniconfig-javafx-aarch64-android.json
@@ -6,6 +6,15 @@
       {"name":"repaintFromNative","parameterTypes":[] }
     ]
   }
+,
+  {
+    "name" : "com.sun.glass.ui.monocle.AndroidInputDeviceRegistry",
+    "methods" : [
+      {"name":"<init>","parameterTypes":[] },
+      {"name":"gotTouchEventFromNative","parameterTypes":["int", "int[]", "int[]", "int[]", "int[]", "int"]},
+      {"name":"gotKeyEventFromNative","parameterTypes":["int", "int"]}
+    ]
+  }
 , 
   {
     "name" : "com.sun.javafx.font.FontConfigManager$FcCompFont",

--- a/src/main/resources/config/jniconfig-javafx-aarch64-android.json
+++ b/src/main/resources/config/jniconfig-javafx-aarch64-android.json
@@ -12,7 +12,8 @@
     "methods" : [
       {"name":"<init>","parameterTypes":[] },
       {"name":"gotTouchEventFromNative","parameterTypes":["int", "int[]", "int[]", "int[]", "int[]", "int"]},
-      {"name":"gotKeyEventFromNative","parameterTypes":["int", "int"]}
+      {"name":"gotKeyEventFromNative","parameterTypes":["int", "int"]},
+      {"name":"registerDevice","parameterTypes":[]}
     ]
   }
 , 

--- a/src/main/resources/native/android/c/grandroid.h
+++ b/src/main/resources/native/android/c/grandroid.h
@@ -4,3 +4,11 @@
 
 #define  LOGD(ignore, ...)  __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #define  LOGE(ignore, ...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#undef com_sun_glass_events_TouchEvent_TOUCH_PRESSED
+#define com_sun_glass_events_TouchEvent_TOUCH_PRESSED 811L
+#undef com_sun_glass_events_TouchEvent_TOUCH_MOVED
+#define com_sun_glass_events_TouchEvent_TOUCH_MOVED 812L
+#undef com_sun_glass_events_TouchEvent_TOUCH_RELEASED
+#define com_sun_glass_events_TouchEvent_TOUCH_RELEASED 813L
+#undef com_sun_glass_events_TouchEvent_TOUCH_STILL
+#define com_sun_glass_events_TouchEvent_TOUCH_STILL 814L

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -17,12 +17,11 @@
 extern int *run_main(int argc, char* argv[]);
 
 extern void requestGlassToRedraw();
-// extern void android_setNativeWindow(ANativeWindow* nativeWindow);
 extern void androidJfx_setNativeWindow(ANativeWindow* nativeWindow);
-extern void android_setDensity(float nativeDensity);
+extern void androidJfx_setDensity(float nativeDensity);
 // extern void Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative
       // (JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys);
-extern void android_gotTouchEvent (int count, int* actions, int* ids, int* xs, int* ys, int primary);
+extern void androidJfx_gotTouchEvent (int count, int* actions, int* ids, int* xs, int* ys, int primary);
 // extern void Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative
       // (JNIEnv *env, jobject activity, jint action, jint keycode);
 extern int to_jfx_touch_action(int state);
@@ -72,7 +71,7 @@ JNIEXPORT jlong JNICALL Java_com_gluonhq_helloandroid_MainActivity_surfaceReady
     window = ANativeWindow_fromSurface(env, surface);
     LOGE(stderr, "now call ANDROID_SETNATIVEWINDOW on openjfx, method = %p or %p\n", androidJfx_setNativeWindow, &androidJfx_setNativeWindow);
     androidJfx_setNativeWindow(window);
-    android_setDensity(mydensity);
+    androidJfx_setDensity(mydensity);
     LOGE(stderr, "SurfaceReady, native window at %p\n", window);
     density = mydensity;
     return (jlong)window;
@@ -103,7 +102,7 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotTouch
             primary = actions[i] == com_sun_glass_events_TouchEvent_TOUCH_RELEASED && jcount == 1 ? -1 : i; 
         }
     }
-    android_gotTouchEvent(jcount, actions, ids, xs, ys, primary);
+    androidJfx_gotTouchEvent(jcount, actions, ids, xs, ys, primary);
 
     (*env)->ReleaseIntArrayElements(env, jactions, actions, 0);
     (*env)->ReleaseIntArrayElements(env, jids, ids, 0);

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -17,6 +17,8 @@
 extern int *run_main(int argc, char* argv[]);
 
 extern void requestGlassToRedraw();
+extern void android_setNativeWindow(ANativeWindow* nativeWindow);
+extern void android_setDensity(float nativeDensity);
 
 ANativeWindow *window;
 jfloat density;
@@ -52,6 +54,7 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurfa
 (JNIEnv *env, jobject activity, jobject surface) {
     LOGE(stderr, "nativeSetSurface called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
     window = ANativeWindow_fromSurface(env, surface);
+    android_setNativeWindow(window);
     LOGE(stderr, "native setSurface Ready, native window at %p\n", window);
 }
 
@@ -59,6 +62,8 @@ JNIEXPORT jlong JNICALL Java_com_gluonhq_helloandroid_MainActivity_surfaceReady
 (JNIEnv *env, jobject activity, jobject surface, jfloat mydensity) {
     LOGE(stderr, "SurfaceReady, surface at %p\n", surface);
     window = ANativeWindow_fromSurface(env, surface);
+    android_setNativeWindow(window);
+    android_setDensity(mydensity);
     LOGE(stderr, "SurfaceReady, native window at %p\n", window);
     density = mydensity;
     return (jlong)window;

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -17,7 +17,8 @@
 extern int *run_main(int argc, char* argv[]);
 
 extern void requestGlassToRedraw();
-extern void android_setNativeWindow(ANativeWindow* nativeWindow);
+// extern void android_setNativeWindow(ANativeWindow* nativeWindow);
+extern void androidJfx_setNativeWindow(ANativeWindow* nativeWindow);
 extern void android_setDensity(float nativeDensity);
 // extern void Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative
       // (JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys);
@@ -58,9 +59,10 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_startGraalApp
 
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurface
 (JNIEnv *env, jobject activity, jobject surface) {
-    LOGE(stderr, "nativeSetSurface called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
+    LOGE(stderr, "nativeSetSurface Called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
     window = ANativeWindow_fromSurface(env, surface);
-    android_setNativeWindow(window);
+    LOGE(stderr, "now call ANDROID_SETNATIVEWINDOW on openjfx, method = %p or %p\n", androidJfx_setNativeWindow, &androidJfx_setNativeWindow);
+    androidJfx_setNativeWindow(window);
     LOGE(stderr, "native setSurface Ready, native window at %p\n", window);
 }
 
@@ -68,7 +70,8 @@ JNIEXPORT jlong JNICALL Java_com_gluonhq_helloandroid_MainActivity_surfaceReady
 (JNIEnv *env, jobject activity, jobject surface, jfloat mydensity) {
     LOGE(stderr, "SurfaceReady, surface at %p\n", surface);
     window = ANativeWindow_fromSurface(env, surface);
-    android_setNativeWindow(window);
+    LOGE(stderr, "now call ANDROID_SETNATIVEWINDOW on openjfx, method = %p or %p\n", androidJfx_setNativeWindow, &androidJfx_setNativeWindow);
+    androidJfx_setNativeWindow(window);
     android_setDensity(mydensity);
     LOGE(stderr, "SurfaceReady, native window at %p\n", window);
     density = mydensity;

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -19,11 +19,12 @@ extern int *run_main(int argc, char* argv[]);
 extern void requestGlassToRedraw();
 extern void android_setNativeWindow(ANativeWindow* nativeWindow);
 extern void android_setDensity(float nativeDensity);
-extern void Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative
-      (JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys);
+// extern void Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative
+      // (JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys);
 extern void android_gotTouchEvent (int count, int* actions, int* ids, int* xs, int* ys, int primary);
-extern void Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative
-      (JNIEnv *env, jobject activity, jint action, jint keycode);
+// extern void Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative
+      // (JNIEnv *env, jobject activity, jint action, jint keycode);
+extern int to_jfx_touch_action(int state);
 
 ANativeWindow *window;
 jfloat density;
@@ -82,8 +83,10 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSurfaceR
 
 
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotTouchEvent
-(JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys) {
+(JNIEnv *env, jobject activity, jint jcount, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys) {
     LOGE(stderr, "Native Dalvik layer got touch event, pass to native Graal layer...");
+
+    jlong jlongids[jcount];
 
     int *actions = (*env)->GetIntArrayElements(env, jactions, 0);
     int *ids = (*env)->GetIntArrayElements(env, jids, 0);
@@ -99,6 +102,12 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotTouch
     }
     android_gotTouchEvent(jcount, actions, ids, xs, ys, primary);
 
+    (*env)->ReleaseIntArrayElements(env, jactions, actions, 0);
+    (*env)->ReleaseIntArrayElements(env, jids, ids, 0);
+    (*env)->ReleaseIntArrayElements(env, jxs, xs, 0);
+    (*env)->ReleaseIntArrayElements(env, jys, ys, 0);
+
+
     // Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative(NULL, NULL, count, jactions, jids, jxs, jys);
     LOGE(stderr, "Native Dalvik layer got touch event, passed to native Graal layer...");
 }
@@ -106,7 +115,7 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotTouch
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotKeyEvent
 (JNIEnv *env, jobject activity, jint action, jint keyCode) {
     LOGE(stderr, "Native Dalvik layer got key event, pass to native Graal layer...");
-    Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative(NULL, NULL, action, keyCode);
+    // Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative(NULL, NULL, action, keyCode);
     LOGE(stderr, "Native Dalvik layer got key event, passed to native Graal layer...");
 }
 

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -19,11 +19,7 @@ extern int *run_main(int argc, char* argv[]);
 extern void requestGlassToRedraw();
 extern void androidJfx_setNativeWindow(ANativeWindow* nativeWindow);
 extern void androidJfx_setDensity(float nativeDensity);
-// extern void Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative
-      // (JNIEnv *env, jobject activity, jint count, jintArray jactions, jintArray jids, jintArray jxs, jintArray jys);
 extern void androidJfx_gotTouchEvent (int count, int* actions, int* ids, int* xs, int* ys, int primary);
-// extern void Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative
-      // (JNIEnv *env, jobject activity, jint action, jint keycode);
 extern int to_jfx_touch_action(int state);
 
 ANativeWindow *window;
@@ -58,9 +54,8 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_startGraalApp
 
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurface
 (JNIEnv *env, jobject activity, jobject surface) {
-    LOGE(stderr, "nativeSetSurface Called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
+    LOGE(stderr, "nativeSetSurface called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
     window = ANativeWindow_fromSurface(env, surface);
-    LOGE(stderr, "now call ANDROID_SETNATIVEWINDOW on openjfx, method = %p or %p\n", androidJfx_setNativeWindow, &androidJfx_setNativeWindow);
     androidJfx_setNativeWindow(window);
     LOGE(stderr, "native setSurface Ready, native window at %p\n", window);
 }
@@ -69,7 +64,6 @@ JNIEXPORT jlong JNICALL Java_com_gluonhq_helloandroid_MainActivity_surfaceReady
 (JNIEnv *env, jobject activity, jobject surface, jfloat mydensity) {
     LOGE(stderr, "SurfaceReady, surface at %p\n", surface);
     window = ANativeWindow_fromSurface(env, surface);
-    LOGE(stderr, "now call ANDROID_SETNATIVEWINDOW on openjfx, method = %p or %p\n", androidJfx_setNativeWindow, &androidJfx_setNativeWindow);
     androidJfx_setNativeWindow(window);
     androidJfx_setDensity(mydensity);
     LOGE(stderr, "SurfaceReady, native window at %p\n", window);
@@ -109,8 +103,6 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotTouch
     (*env)->ReleaseIntArrayElements(env, jxs, xs, 0);
     (*env)->ReleaseIntArrayElements(env, jys, ys, 0);
 
-
-    // Java_com_sun_glass_ui_android_DalvikInput_onMultiTouchEventNative(NULL, NULL, count, jactions, jids, jxs, jys);
     LOGE(stderr, "Native Dalvik layer got touch event, passed to native Graal layer...");
 }
 
@@ -118,7 +110,7 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeGotKeyEv
 (JNIEnv *env, jobject activity, jint action, jint keyCode) {
     LOGE(stderr, "Native Dalvik layer got key event, pass to native Graal layer...");
     // Java_com_sun_glass_ui_android_DalvikInput_onKeyEventNative(NULL, NULL, action, keyCode);
-    LOGE(stderr, "Native Dalvik layer got key event, passed to native Graal layer...");
+    LOGE(stderr, "Native Dalvik layer got key event, TODO!!!");
 }
 
 // == expose window functionality to JavaFX native code == //


### PR DESCRIPTION
This PR passed multi-touch events from the Android activity to the native code in launcher.c, then to the native JavaFX code (requires latest gvm-ea+3a release) and then to the Java JavaFX code.