### PR TITLE
AppId should have a default value

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -350,8 +350,13 @@ public class InternalProjectConfiguration {
         this.runtimeArgsList = runtimeArgsList;
     }
 
+    /**
+     * Returns the appId from {@link ProjectConfiguration}. If the appId is null, a concatenation of strings
+     * "com.gluonhq." and a random string with 6 alphabets, is returned.
+     * @return appId from {@link ProjectConfiguration}. If the appId is null, it will return a random string.
+     */
     public String getAppId() {
-        return Objects.requireNonNull(publicConfig.getAppId(), "App ID is required");
+        return Optional.ofNullable(publicConfig.getAppId()).orElse("com.gluonhq." + Strings.randomString(6));
     }
 
     public String getAppName() {

--- a/src/main/java/com/gluonhq/substrate/util/Strings.java
+++ b/src/main/java/com/gluonhq/substrate/util/Strings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2019, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -95,6 +96,16 @@ public final class Strings {
      */
     public static List<String> split(String s, String delimiter) {
         return s == null || s.trim().isEmpty() ? Collections.emptyList() : Arrays.asList(s.split(delimiter));
+    }
+
+    public static String randomString(int targetStringLength) {
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        Random random = new Random();
+        return random.ints(leftLimit, rightLimit + 1)
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
     }
 
 }

--- a/src/test/java/com/gluonhq/substrate/util/StringsTests.java
+++ b/src/test/java/com/gluonhq/substrate/util/StringsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2019, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,6 +100,13 @@ public class StringsTests {
                 Collections.emptyList(),
                 Strings.split( null ));
 
+    }
+    
+    @Test
+    void randomStringGeneration() {
+        final String randomString = Strings.randomString(6);
+        assertEquals(6, randomString.length());
+        assertTrue(randomString.matches("^[a-z]*$"));
     }
 
 


### PR DESCRIPTION
If `ProjectConfiguration#getAppId returns `null`, `InternalProjectConfiguration` should return a default string with `com.gluonhq.<random-string>`.