### PR TITLE
Supporting custom native code in project

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -114,6 +114,7 @@ public class Constants {
     public static final String TMP_PATH = "tmp";
     public static final String LIB_PATH = "lib";
     public static final String LOG_PATH = "log";
+    public static final String NATIVE_CODE_PATH = "native";
 
 
 

--- a/src/main/java/com/gluonhq/substrate/model/ProcessPaths.java
+++ b/src/main/java/com/gluonhq/substrate/model/ProcessPaths.java
@@ -44,6 +44,7 @@ public class ProcessPaths {
     private Path tmpPath;
     private Path logPath;
     private Path sourcePath;
+    private Path nativeCodePath;
 
     /**
      * |-- build or target
@@ -73,6 +74,7 @@ public class ProcessPaths {
         tmpPath = Files.createDirectories(gvmPath.resolve(Constants.TMP_PATH));
         logPath = Files.createDirectories(gvmPath.resolve(Constants.LOG_PATH));
         sourcePath = clientPath.getParent().getParent().resolve(Constants.SOURCE_PATH);
+        nativeCodePath = sourcePath.getParent().resolve(Constants.NATIVE_CODE_PATH);
     }
 
     public Path getBuildRoot() {
@@ -105,6 +107,10 @@ public class ProcessPaths {
 
     public Path getLogPath() {
         return logPath;
+    }
+
+    public Path getNativeCodePath() {
+        return nativeCodePath;
     }
 }
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -769,11 +769,11 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return Arrays.asList("-o", getAppPath(appName));
     }
 
-    Path getNativeCodePath() {
+    protected Path getNativeCodePath() {
         return paths.getSourcePath().getParent().resolve("native");
     }
 
-    List<String> getNativeCodeList() throws IOException {
+    protected List<String> getNativeCodeList() throws IOException {
         Path nativeCodeDir = getNativeCodePath();
         if (!Files.exists(nativeCodeDir))
             return Collections.emptyList();

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -773,7 +773,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return Arrays.asList("-o", getAppPath(appName));
     }
 
-    List<String> getTargetNativeCodeExtensions() {
+    protected List<String> getTargetNativeCodeExtensions() {
         return Arrays.asList(".c");
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -41,7 +41,6 @@ import com.gluonhq.substrate.util.Strings;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -220,8 +219,11 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         linkBuilder.command().add(objectFile.toString());
         linkBuilder.command().addAll(getTargetSpecificObjectFiles());
 
-        getNativeCodeList().forEach(sourceFile -> linkBuilder.command()
-        .add(gvmAppPath.resolve(sourceFile.replaceAll("\\..*", "." + getObjectFileExtension())).toString()));
+        getNativeCodeList().stream()
+            .map(s -> s.replaceAll("\\..*", "." + getObjectFileExtension()))
+            .distinct()
+            .collect(Collectors.toList())
+            .forEach(sourceFile -> linkBuilder.command().add(gvmAppPath.resolve(sourceFile).toString()));
 
         getTargetSpecificLinkLibraries().forEach(linkBuilder.command()::add);
         linkBuilder.command().addAll(getTargetSpecificLinkFlags(projectConfiguration.isUseJavaFX(), projectConfiguration.isUsePrismSW()));
@@ -777,6 +779,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             return Collections.emptyList();
         return Files.list(nativeCodeDir)
             .map(p -> p.getFileName().toString())
+            .filter(s -> s.endsWith(".c") || s.endsWith(".h"))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -328,7 +328,8 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         
         Path nativeCodeDir = paths.getNativeCodePath();
-        FileOps.copyDirectory(nativeCodeDir, workDir);
+        if (Files.isDirectory(nativeCodeDir))
+            FileOps.copyDirectory(nativeCodeDir, workDir);
 
         for( String fileName: getNativeCodeList() ) {
             processBuilder.command().add(fileName);

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -222,7 +222,6 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         getNativeCodeList().stream()
             .map(s -> s.replaceAll("\\..*", "." + getObjectFileExtension()))
             .distinct()
-            .collect(Collectors.toList())
             .forEach(sourceFile -> linkBuilder.command().add(gvmAppPath.resolve(sourceFile).toString()));
 
         getTargetSpecificLinkLibraries().forEach(linkBuilder.command()::add);
@@ -328,8 +327,9 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         
         Path nativeCodeDir = paths.getNativeCodePath();
-        if (Files.isDirectory(nativeCodeDir))
+        if (Files.isDirectory(nativeCodeDir)) {
             FileOps.copyDirectory(nativeCodeDir, workDir);
+        }
 
         for( String fileName: getNativeCodeList() ) {
             processBuilder.command().add(fileName);
@@ -773,13 +773,19 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return Arrays.asList("-o", getAppPath(appName));
     }
 
+    List<String> getTargetNativeCodeExtensions() {
+        return Arrays.asList(".c");
+    }
+
     protected List<String> getNativeCodeList() throws IOException {
         Path nativeCodeDir = paths.getNativeCodePath();
-        if (!Files.exists(nativeCodeDir))
+        if (!Files.exists(nativeCodeDir)) {
             return Collections.emptyList();
+        }
+        List<String> extensions = getTargetNativeCodeExtensions();
         return Files.list(nativeCodeDir)
             .map(p -> p.getFileName().toString())
-            .filter(s -> s.endsWith(".c"))
+            .filter(s -> extensions.stream().anyMatch(e -> s.endsWith(e)))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -319,20 +319,23 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             processBuilder.command().add("-DGVM_VERBOSE");
         }
         processBuilder.command().addAll(getTargetSpecificCCompileFlags());
+
+        processBuilder.command().add("-I" + workDir.toString());
+
         for( String fileName: getAdditionalSourceFiles() ) {
             FileOps.copyResource(getAdditionalSourceFileLocation()  + fileName, workDir.resolve(fileName));
             processBuilder.command().add(fileName);
         }
         
-        Path nativeCodeDir = getNativeCodePath();
+        Path nativeCodeDir = paths.getNativeCodePath();
+        FileOps.copyDirectory(nativeCodeDir, workDir);
+
         for( String fileName: getNativeCodeList() ) {
-            FileOps.copyFile(nativeCodeDir.resolve(fileName), workDir.resolve(fileName));
             processBuilder.command().add(fileName);
         }
 
         for( String fileName: getAdditionalHeaderFiles() ) {
             FileOps.copyResource(getAdditionalSourceFileLocation()  + fileName, workDir.resolve(fileName));
-            processBuilder.command().add(fileName);
         }
   
         processBuilder.directory(workDir.toFile());
@@ -769,17 +772,13 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return Arrays.asList("-o", getAppPath(appName));
     }
 
-    protected Path getNativeCodePath() {
-        return paths.getSourcePath().getParent().resolve("native");
-    }
-
     protected List<String> getNativeCodeList() throws IOException {
-        Path nativeCodeDir = getNativeCodePath();
+        Path nativeCodeDir = paths.getNativeCodePath();
         if (!Files.exists(nativeCodeDir))
             return Collections.emptyList();
         return Files.list(nativeCodeDir)
             .map(p -> p.getFileName().toString())
-            .filter(s -> s.endsWith(".c") || s.endsWith(".h"))
+            .filter(s -> s.endsWith(".c"))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -44,7 +44,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -179,10 +179,15 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
 
     @Override
     protected List<String> getTargetSpecificCCompileFlags() {
+        List<String> flags = Arrays.asList("-I" + 
+            projectConfiguration.getGraalPath().resolve("include").toString(),
+            "-I" + projectConfiguration.getGraalPath().resolve("include").resolve("linux").toString()
+            );
+            
         if (projectConfiguration.getTargetTriplet().getArch().equals(Constants.ARCH_AARCH64)) {
-            return Arrays.asList("-DAARCH64");
+            flags.add("-DAARCH64");
         }
-        return Collections.emptyList();
+        return flags;
     }
 
    /*

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -243,7 +243,6 @@ public class FileOps {
      * @throws IOException if an exception happens when listing the content
      */
     public static void copyDirectory(Path source, Path destination) throws IOException {
-        copyFile(source, destination);
         if (Files.isDirectory(source)) {
             List<Path> fileNames = Files.list(source)
                     .map(Path::getFileName)
@@ -252,6 +251,8 @@ public class FileOps {
                 copyDirectory(source.resolve(fileName), destination.resolve(fileName));
             }
         }
+        else
+            copyFile(source, destination);
     }
 
     /**


### PR DESCRIPTION
This PR adds support for `native` directory in project which can contain native `.h` or `.c` files which would be included for compilation and linking. Without this modification you either need to insert files in `target` manually or to rebuild Substrate each time you make changes in native code. 

Example usage can be seen here: https://github.com/lazar-mitrovic/HelloNative

PR also includes `jni.h` location for linux target.