### PR TITLE
Increase number of retries and delay b/w each retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,4 +113,6 @@ nexusPublishing {
 nexusStaging {
     username = project.hasProperty('sonatypeUsername') ? project.property('sonatypeUsername') : ''
     password = project.hasProperty('sonatypePassword') ? project.property('sonatypePassword') : ''
+    numberOfRetries = 30
+    delayBetweenRetriesInMillis = 3000
 }


### PR DESCRIPTION
Last 2 releases have failed because the nexus-staging plugin wasn't able to close and release the repository.

Increasing number of retries and wait time b/w each retry might be useful to tackle this situation.