### PR TITLE
#360 Create debug.keystore in .gluon/subtrate

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -128,6 +128,7 @@ public class Constants {
      * Supported files
      */
     public static final String PLIST_FILE = "Default-Info.plist";
+    public static final String ANDROID_KEYSTORE = "debug.keystore";
 
     public static final String META_INF_SUBSTRATE_CONFIG = "META-INF/substrate/config/";
     public static final String USER_INIT_BUILD_TIME_FILE = "initbuildtime";

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -32,6 +32,7 @@ import com.gluonhq.substrate.model.ClassPath;
 import com.gluonhq.substrate.model.InternalProjectConfiguration;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.util.FileOps;
+import com.gluonhq.substrate.util.Logger;
 import com.gluonhq.substrate.util.ProcessRunner;
 import com.gluonhq.substrate.util.Version;
 
@@ -220,8 +221,8 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
         createDevelopKeystore();
 
-        ProcessRunner sign =  new ProcessRunner(buildToolsPath.resolve("apksigner").toString(), "sign", "--ks", 
-            paths.getGvmPath().resolve("debug.keystore").toString(), "--ks-key-alias", "androiddebugkey", "--ks-pass", "pass:android", "--key-pass", "pass:android",  alignedApk);
+        ProcessRunner sign =  new ProcessRunner(buildToolsPath.resolve("apksigner").toString(), "sign", "--ks",
+                Constants.USER_SUBSTRATE_PATH.resolve(Constants.ANDROID_KEYSTORE).toString(), "--ks-key-alias", "androiddebugkey", "--ks-pass", "pass:android", "--key-pass", "pass:android",  alignedApk);
         processResult = sign.runProcess("sign");
         
         return processResult == 0;
@@ -381,10 +382,10 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     }
 
     private void createDevelopKeystore() throws IOException, InterruptedException {
-        Path keystore = paths.getGvmPath().resolve("debug.keystore");
+        Path keystore = Constants.USER_SUBSTRATE_PATH.resolve(Constants.ANDROID_KEYSTORE);
         
         if (Files.exists(keystore)) {
-            System.err.println("ks exists, skipping");
+            Logger.logDebug("The " + Constants.ANDROID_KEYSTORE + " file already exists, skipping");
             return;
         }
 
@@ -396,7 +397,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         if (processResult != 0)
             throw new IllegalArgumentException("fatal, can not create a keystore");
 
-        System.err.println("done creating ks");
+        Logger.logDebug("Done creating " + Constants.ANDROID_KEYSTORE);
     }
 
     private String findLatestBuildTool(Path sdkPath) throws IOException {


### PR DESCRIPTION
This PR moves the `debug.keystore` from `target/client/archOS/gvm` to `~/.gluon/substrate`, so we have to create it just once. 

This will allow compiling, linking and deploying the same project all over again without the need of removing it (because the keystore changed after cleaning target).

Fixes #360. 
