### PR TITLE
Fix for w+e pages (enables api level 28 for PlayStore)

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -58,7 +58,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     private List<String> androidAdditionalSourceFiles = Collections.singletonList("launcher.c");
     private List<String> androidAdditionalHeaderFiles = Collections.singletonList("grandroid.h");
     private List<String> cFlags = Arrays.asList("-target", "aarch64-linux-android", "-I.");
-    private List<String> linkFlags = Arrays.asList("-target", "aarch64-linux-android21", "-fPIC", "-Wl,--gc-sections",
+    private List<String> linkFlags = Arrays.asList("-target", "aarch64-linux-android21", "-fPIC", "-fuse-ld=gold", "-Wl,--rosegment,--gc-sections,-z,noexecstack",
             "-landroid", "-llog", "-lnet", "-shared", "-lffi");
     private List<String> javafxLinkFlags = Arrays.asList("-Wl,--whole-archive",
             "-lprism_es2_monocle", "-lglass_monocle", "-ljavafx_font_freetype", "-ljavafx_iio", "-Wl,--no-whole-archive",

--- a/src/main/resources/native/android/AndroidManifest.xml
+++ b/src/main/resources/native/android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <manifest xmlns:a='http://schemas.android.com/apk/res/android' package='com.gluonhq.helloandroid' a:versionCode='1' a:versionName='1.0'>
     <supports-screens a:xlargeScreens="true"/>
-    <uses-sdk a:minSdkVersion="21" a:targetSdkVersion="21"/>
+    <uses-sdk a:minSdkVersion="21" a:targetSdkVersion="28"/>
     <application a:label='A HelloGraal' a:icon="@mipmap/ic_launcher">
         <activity a:name='com.gluonhq.helloandroid.MainActivity' a:configChanges="orientation|keyboardHidden">
              <intent-filter>


### PR DESCRIPTION
Since Google PlayStore now [requires API level 28](https://support.google.com/googleplay/android-developer/answer/113469#targetsdk) to publish apps, fix was needed to disable segments that are writable and executable (which are [forbidden since API level 26](https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#writable-and-executable-segments-enforced-for-api-level-26)). 

ELF generated with standard Android NDK's `ld` linker using default linker script contained combined section for `text` and `rodata` which would be r+w+e:
```
$ readelf --program-headers -W libmygraal.so 
Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x4b97388 0x4b97b58 RWE 0x10000
``` 

Using `ld.gold` linker (which is provided in NDK) instead of default one allows `--rosegment` and `-z noexecstack` parameters to be passed by `clang` which would separate `rodata` segment from `text` and remove `e` flag from stack, thus fulfilling said requirement. 

```
$ readelf --program-headers -W libmygraal.so 
Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x0001f8 0x0001f8 R   0x8
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x1074c1c 0x1074c1c R E 0x10000
```