### PR TITLE
Notify on openURL calls for iOS

### DIFF
--- a/src/main/resources/native/ios/AppDelegate.m
+++ b/src/main/resources/native/ios/AppDelegate.m
@@ -109,6 +109,32 @@ int main(int argc, char * argv[]) {
     gvmlog(@"[UIAPP] applicationWillTerminate");
 }
 
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<NSString *, id> *)options {
+
+    gvmlog(@"[UIAPP] application_openURL_options");
+
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:@"UIApplicationOpenURLNotification"
+        object:self userInfo:[NSDictionary dictionaryWithObject:url forKey:@"URL"]];
+
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            sourceApplication:(NSString *)sourceApplication
+            annotation:(id)annotation {
+
+    gvmlog(@"[UIAPP] application_openURL_sourceApplication_annotation");
+
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:@"UIApplicationOpenURLNotification"
+        object:self userInfo:[NSDictionary dictionaryWithObject:url forKey:@"URL"]];
+
+    return YES;
+}
 
 @end
 


### PR DESCRIPTION
This provides Attach services the ability to listen for `openURL` calls and handle them accordingly.

An example use case for this is Firebase, where the module needs to handle this callback from Google Sign In: https://developers.google.com/identity/sign-in/ios/sign-in?ver=objc#enable_sign-in

I'm not sure if this is the best approach for this, let me know if there's something better that I could do in the Attach service itself :)