### PR TITLE
Add support for signing with Gradle and GPG 2.1+

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,7 @@ jobs:
 
       - name: Import GPG keys
         run: |
-          echo $GPG_PRIVATE_KEY > /tmp/secret
-          gpg --import --batch /tmp/secret &> /dev/null
+          gpg --import --batch <(echo "$GPG_PRIVATE_KEY") &> /dev/null
           rm -rf /tmp/secret
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,12 @@ jobs:
       - name: Import GPG keys
         run: |
           gpg --import --batch <(echo "$GPG_PRIVATE_KEY") &> /dev/null
+          # Gradle doesn't support GPG 2.1 and later: https://github.com/gradle/gradle/issues/888
+          gpg --export-secret-keys --pinentry-mode loopback --passphrase="$GPG_PASSPHRASE" > ~/.gnupg/secring.gpg
           rm -rf /tmp/secret
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Deploy to Sonatype Nexus
         id: deploy


### PR DESCRIPTION
Makes two changes:

* Do not store the content of `GPG_PRIVATE_KEY` to a file. Instead echo it directly to `gpg --import` command
* GPG 2.1 and later doesn't create a secring file when a secret key is imported. Gradle doesn't support signing without the secret key. Therefore, we need to explicitly create the `secring.gpg` file