### PR TITLE
Update JavaFX static version to 15-ea+gvm16

### DIFF
--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -12,7 +12,7 @@ def getGraalVMPath() {
 }
 
 def setupJavaFXDependencies(String platform, String target) {
-    def version = "15-ea+gvm11"
+    def version = "15-ea+gvm16"
     def name
     if ("linux" == platform) {
         name = "linux-x86_64"


### PR DESCRIPTION
The gradle build script inside the test-project downloads a specific version of the javafx static libraries. This PR upgrades the version that is downloaded to `15-ea+gvm16`.