### PR TITLE
Move javafx static libs download to CI script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-linux-20.1-latest
-          export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-linux/sdk/lib
+          export JAVAFX_STATIC_SDK=$HOME/javafx-static-libs-linux/sdk
           export DISPLAY=:90
           mkdir /home/runner/.vnc
           echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
@@ -91,8 +91,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
-          export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-darwin/sdk/lib
-          export JAVAFX_STATIC_LIBS_IOS=$HOME/javafx-static-libs-ios/sdk/lib
+          export JAVAFX_STATIC_SDK=$HOME/javafx-static-libs-darwin/sdk
+          export JAVAFX_STATIC_SDK_IOS=$HOME/javafx-static-libs-ios/sdk
           ./gradlew -i test
 
       - name: Build project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,27 @@ jobs:
           wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-darwin-20.1-latest.zip
           unzip graalvm-svm-darwin-20.1-latest && cd $GITHUB_WORKSPACE
 
+      - name: Install linux JavaFX static libs (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-linux-x86_64-static.zip
+          unzip openjfx-15-ea+gvm16-linux-x86_64-static.zip && cd $GITHUB_WORKSPACE
+
+      - name: Install darwin JavaFX static libs (MacOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-darwin-x86_64-static.zip
+          unzip openjfx-15-ea+gvm16-darwin-x86_64-static.zip && cd $GITHUB_WORKSPACE
+
+      - name: Install iOS JavaFX static libs (MacOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p $HOME/javafx-static-libs-ios && cd $HOME/javafx-static-libs-ios
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-ios-arm64-static.zip
+          unzip openjfx-15-ea+gvm16-ios-arm64-static.zip && cd $GITHUB_WORKSPACE
+    
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -57,6 +78,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-linux-20.1-latest
+          export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-linux/sdk/lib
           export DISPLAY=:90
           mkdir /home/runner/.vnc
           echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
@@ -69,6 +91,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
+          export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-darwin/sdk/lib
+          export JAVAFX_STATIC_LIBS_IOS=$HOME/javafx-static-libs-ios/sdk/lib
           ./gradlew -i test
 
       - name: Build project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,22 +46,22 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
-          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-linux-x86_64-static.zip
-          unzip openjfx-15-ea+gvm16-linux-x86_64-static.zip && cd $GITHUB_WORKSPACE
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-linux-x86_64-static.zip
+          unzip openjfx-15-latest-linux-x86_64-static.zip && cd $GITHUB_WORKSPACE
 
       - name: Install darwin JavaFX static libs (MacOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
-          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-darwin-x86_64-static.zip
-          unzip openjfx-15-ea+gvm16-darwin-x86_64-static.zip && cd $GITHUB_WORKSPACE
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-darwin-x86_64-static.zip
+          unzip openjfx-15-latest-darwin-x86_64-static.zip && cd $GITHUB_WORKSPACE
 
       - name: Install iOS JavaFX static libs (MacOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/javafx-static-libs-ios && cd $HOME/javafx-static-libs-ios
-          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-ios-arm64-static.zip
-          unzip openjfx-15-ea+gvm16-ios-arm64-static.zip && cd $GITHUB_WORKSPACE
+          wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-ios-arm64-static.zip
+          unzip openjfx-15-latest-ios-arm64-static.zip && cd $GITHUB_WORKSPACE
     
       - name: Checkout
         uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,11 @@ matrix:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
         - wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-linux-20.1-latest.zip
         - unzip graalvm-svm-linux-20.1-latest.zip && cd $TRAVIS_BUILD_DIR
+        - mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-linux-x86_64-static.zip
+        - unzip openjfx-15-ea+gvm16-linux-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-linux-20.1-latest
+        - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-linux/sdk/lib
         - export JAVA_HOME=$GRAALVM_HOME
     - os: osx
       osx_image: xcode10.2
@@ -47,7 +51,15 @@ matrix:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
         - wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-darwin-20.1-latest.zip
         - unzip graalvm-svm-darwin-20.1-latest.zip && cd $TRAVIS_BUILD_DIR
+        - mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-darwin-x86_64-static.zip
+        - unzip openjfx-15-ea+gvm16-darwin-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
+        - mkdir -p $HOME/javafx-static-libs-ios && cd $HOME/javafx-static-libs-ios
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-ios-arm64-static.zip
+        - unzip openjfx-15-ea+gvm16-ios-arm64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
+        - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-darwin/sdk/lib
+        - export JAVAFX_STATIC_LIBS_IOS=$HOME/javafx-static-libs-ios/sdk/lib
         - export JAVA_HOME=$GRAALVM_HOME
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-ios-arm64-static.zip
         - unzip openjfx-15-latest-ios-arm64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
-        - export JAVAFX_STATICSDK=$HOME/javafx-static-libs-darwin/sdk
+        - export JAVAFX_STATIC_SDK=$HOME/javafx-static-libs-darwin/sdk
         - export JAVAFX_STATIC_SDK_IOS=$HOME/javafx-static-libs-ios/sdk
         - export JAVA_HOME=$GRAALVM_HOME
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ matrix:
         - wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-linux-20.1-latest.zip
         - unzip graalvm-svm-linux-20.1-latest.zip && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
-        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-linux-x86_64-static.zip
-        - unzip openjfx-15-ea+gvm16-linux-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-linux-x86_64-static.zip
+        - unzip openjfx-15-latest-linux-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-linux-20.1-latest
         - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-linux/sdk/lib
         - export JAVA_HOME=$GRAALVM_HOME
@@ -52,11 +52,11 @@ matrix:
         - wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-darwin-20.1-latest.zip
         - unzip graalvm-svm-darwin-20.1-latest.zip && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
-        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-darwin-x86_64-static.zip
-        - unzip openjfx-15-ea+gvm16-darwin-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-darwin-x86_64-static.zip
+        - unzip openjfx-15-latest-darwin-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-ios && cd $HOME/javafx-static-libs-ios
-        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-ea+gvm16-ios-arm64-static.zip
-        - unzip openjfx-15-ea+gvm16-ios-arm64-static.zip && cd $TRAVIS_BUILD_DIR
+        - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-ios-arm64-static.zip
+        - unzip openjfx-15-latest-ios-arm64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
         - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-darwin/sdk/lib
         - export JAVAFX_STATIC_LIBS_IOS=$HOME/javafx-static-libs-ios/sdk/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-linux-x86_64-static.zip
         - unzip openjfx-15-latest-linux-x86_64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-linux-20.1-latest
-        - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-linux/sdk/lib
+        - export JAVAFX_STATIC_SDK=$HOME/javafx-static-libs-linux/sdk
         - export JAVA_HOME=$GRAALVM_HOME
     - os: osx
       osx_image: xcode10.2
@@ -58,8 +58,8 @@ matrix:
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-ios-arm64-static.zip
         - unzip openjfx-15-latest-ios-arm64-static.zip && cd $TRAVIS_BUILD_DIR
         - export GRAALVM_HOME=$HOME/graalvm/graalvm-svm-darwin-20.1-latest
-        - export JAVAFX_STATIC_LIBS=$HOME/javafx-static-libs-darwin/sdk/lib
-        - export JAVAFX_STATIC_LIBS_IOS=$HOME/javafx-static-libs-ios/sdk/lib
+        - export JAVAFX_STATICSDK=$HOME/javafx-static-libs-darwin/sdk
+        - export JAVAFX_STATIC_SDK_IOS=$HOME/javafx-static-libs-ios/sdk
         - export JAVA_HOME=$GRAALVM_HOME
 
 before_script:

--- a/src/test/java/com/gluonhq/substrate/IOSTest.java
+++ b/src/test/java/com/gluonhq/substrate/IOSTest.java
@@ -105,6 +105,7 @@ class IOSTest {
         BuildResult result = GradleRunner.create()
                 .withProjectDir(new File("test-project"))
                 .withArguments(":helloWorld:clean", ":helloWorld:build",
+                        "-Djavafx.static.libs=" + System.getenv("JAVAFX_STATIC_LIBS_IOS"),
                         "-Dsubstrate.target=ios", "-Dskipsigning=" + skipSigning,
                         ":helloWorld:run", ":helloWorld:runScript", "--stacktrace")
                 .forwardOutput()
@@ -121,6 +122,7 @@ class IOSTest {
         BuildResult result = GradleRunner.create()
                 .withProjectDir(new File("test-project"))
                 .withArguments(":helloFX:clean", ":helloFX:build",
+                        "-Djavafx.static.libs=" + System.getenv("JAVAFX_STATIC_LIBS_IOS"),
                         "-Dsubstrate.target=ios", ":helloFX:run", ":helloFX:runScript", "--stacktrace")
                 .forwardOutput()
                 .build();

--- a/src/test/java/com/gluonhq/substrate/IOSTest.java
+++ b/src/test/java/com/gluonhq/substrate/IOSTest.java
@@ -105,7 +105,7 @@ class IOSTest {
         BuildResult result = GradleRunner.create()
                 .withProjectDir(new File("test-project"))
                 .withArguments(":helloWorld:clean", ":helloWorld:build",
-                        "-Djavafx.static.libs=" + System.getenv("JAVAFX_STATIC_LIBS_IOS"),
+                        "-Djavafx.static.sdk=" + System.getenv("JAVAFX_STATIC_SDK_IOS"),
                         "-Dsubstrate.target=ios", "-Dskipsigning=" + skipSigning,
                         ":helloWorld:run", ":helloWorld:runScript", "--stacktrace")
                 .forwardOutput()
@@ -122,7 +122,7 @@ class IOSTest {
         BuildResult result = GradleRunner.create()
                 .withProjectDir(new File("test-project"))
                 .withArguments(":helloFX:clean", ":helloFX:build",
-                        "-Djavafx.static.libs=" + System.getenv("JAVAFX_STATIC_LIBS_IOS"),
+                        "-Djavafx.static.sdk=" + System.getenv("JAVAFX_STATIC_SDK_IOS"),
                         "-Dsubstrate.target=ios", ":helloFX:run", ":helloFX:runScript", "--stacktrace")
                 .forwardOutput()
                 .build();

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -14,12 +14,12 @@ def validateGraalvmHome() {
     return graalvmHome
 }
 
-def validateJavafxStaticLibs() {
-    def javafxStaticLibs = hasProperty('javafx.static.libs') ? getProperty('javafx.static.libs') : System.getenv('JAVAFX_STATIC_LIBS')
-    if (javafxStaticLibs == null || !file(javafxStaticLibs).exists()) {
-        throw new GradleException("JAVAFX_STATIC_LIBS is not defined or is pointing to a non-existing directory: ${javafxStaticLibs}")
+def validateJavafxStaticSdk() {
+    def javafxStaticSdk = hasProperty('javafx.static.sdk') ? getProperty('javafx.static.sdk') : System.getenv('JAVAFX_STATIC_SDK')
+    if (javafxStaticSdk == null || !file(javafxStaticSdk).exists()) {
+        throw new GradleException("JAVAFX_STATIC_SDK is not defined or is pointing to a non-existing directory: ${javafxStaticSdk}")
     }
-    return javafxStaticLibs
+    return javafxStaticSdk
 }
 
 subprojects {

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -1,53 +1,28 @@
-plugins {
-    id "com.google.osdetector" version "1.6.2" apply false
+def validateJavaHome() {
+    def javaHome = hasProperty('org.gradle.java.home') ? getProperty('org.gradle.java.home') : System.getenv('JAVA_HOME')
+    if (javaHome == null || !file(javaHome).exists()) {
+        throw new GradleException("JAVA_HOME is not defined or is pointing to a non-existing directory: ${javaHome}")
+    }
+    return javaHome
 }
 
-def getGraalVMPath() {
-    def gvmHome = System.getenv("GRAALVM_HOME")
-    if (gvmHome != null && new File(gvmHome).exists()) {
-        return gvmHome
+def validateGraalvmHome() {
+    def graalvmHome = System.getenv('GRAALVM_HOME')
+    if (graalvmHome == null || !file(graalvmHome).exists()) {
+        throw new GradleException("GRAALVM_HOME is not defined or is pointing to a non-existing directory: ${graalvmHome}")
     }
-
-    throw new GradleException("GRAALVM_HOME is not set or is pointing to a non-existing directory: $gvmHome")
+    return graalvmHome
 }
 
-def setupJavaFXDependencies(String platform, String target) {
-    def version = "15-ea+gvm16"
-    def name
-    if ("linux" == platform) {
-        name = "linux-x86_64"
-    } else if ("mac" == platform) {
-        if ("ios" == "$target") {
-            name = "ios-arm64"
-        } else {
-            name = "darwin-x86_64"
-        }
-    } else if ("win" == platform) {
-        name = "windows-x86_64"
-    } else {
-        throw new GradleException("Platform $platform or Target $target not supported")
+def validateJavafxStaticLibs() {
+    def javafxStaticLibs = hasProperty('javafx.static.libs') ? getProperty('javafx.static.libs') : System.getenv('JAVAFX_STATIC_LIBS')
+    if (javafxStaticLibs == null || !file(javafxStaticLibs).exists()) {
+        throw new GradleException("JAVAFX_STATIC_LIBS is not defined or is pointing to a non-existing directory: ${javafxStaticLibs}")
     }
-    def javafxSdk = new File("${System.properties['user.home']}/.gluon/substrate/javafxStaticSdk")
-    def javafxFolder = new File("$javafxSdk/$version/$name")
-    def nameZip = "openjfx-$version-$name-static.zip"
-    def javafxZip = new File("$javafxSdk/$nameZip")
-    if (!javafxFolder.exists()) {
-        javafxSdk.mkdirs()
-        println "Downloading javafxZip..."
-        new URL("https://download2.gluonhq.com/substrate/javafxstaticsdk/$nameZip")
-                .withInputStream { i -> javafxZip.withOutputStream { it << i } }
-        javafxFolder.mkdirs()
-        copy {
-            from zipTree(javafxZip)
-            into javafxFolder
-        }
-        javafxZip.delete()
-    }
-    return "$javafxFolder" + "/sdk/lib"
+    return javafxStaticLibs
 }
 
 subprojects {
-    apply plugin: 'com.google.osdetector'
     apply plugin: 'application'
 
     ext.substrateVersion = "0.0.3"
@@ -59,10 +34,7 @@ subprojects {
             ext.substrateVersion = props['version']
         }
     }
-    ext.platform = osdetector.os == 'osx' ? 'mac' : osdetector.os == 'windows' ? 'win' : osdetector.os
 
     sourceCompatibility = 11
     targetCompatibility = 11
 }
-
-

--- a/test-project/helloFX/build.gradle
+++ b/test-project/helloFX/build.gradle
@@ -29,13 +29,14 @@ task runScript(type: Exec) {
 
     def javaHome = validateJavaHome()
     def graalvmHome = validateGraalvmHome()
-    def javafxStaticLibs = validateJavafxStaticLibs()
+    def javafxStaticSdk = validateJavafxStaticSdk()
 
     def expected = System.getProperty("expected")
 
     def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:" +
+                    "-Dimagecp=${javafxStaticSdk}/lib/javafx.base.jar:${javafxStaticSdk}/lib/javafx.graphics.jar:${javafxStaticSdk}/lib/javafx.controls.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
+                    "-Djavafxsdk=${javafxStaticSdk}",
                     "-Dgraalvm=${graalvmHome}"]
     if (target != null) {
         argsList += ["-DtargetProfile=$target"]

--- a/test-project/helloFX/build.gradle
+++ b/test-project/helloFX/build.gradle
@@ -24,24 +24,19 @@ javafx {
 
 mainClassName = "com.gluonhq.substrate.test.Main"
 
-def java_home = hasProperty('org.gradle.java.home') ? getProperty('org.gradle.java.home') : System.getenv('JAVA_HOME')
-
 task runScript(type: Exec) {
     dependsOn 'build'
 
-    if (java_home == null) {
-        throw new RuntimeException("java_home is not defined.")
-    }
-
-    def graalvmPath = getGraalVMPath()
-    def javafxPath = setupJavaFXDependencies(platform, target)
+    def javaHome = validateJavaHome()
+    def graalvmHome = validateGraalvmHome()
+    def javafxStaticLibs = validateJavafxStaticLibs()
 
     def expected = System.getProperty("expected")
 
-    def argsList = ["${java_home}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxPath}/javafx.base.jar:${javafxPath}/javafx.graphics.jar:${javafxPath}/javafx.controls.jar:" +
+    def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
+                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
-                    "-Dgraalvm=$graalvmPath"]
+                    "-Dgraalvm=${graalvmHome}"]
     if (target != null) {
         argsList += ["-DtargetProfile=$target"]
     } else {

--- a/test-project/helloFXML/build.gradle
+++ b/test-project/helloFXML/build.gradle
@@ -24,24 +24,19 @@ javafx {
 
 mainClassName = "com.gluonhq.substrate.test.Main"
 
-def java_home = hasProperty('org.gradle.java.home') ? getProperty('org.gradle.java.home') : System.getenv('JAVA_HOME')
-
 task runScript(type: Exec) {
     dependsOn 'build'
 
-    if (java_home == null) {
-        throw new RuntimeException("java_home is not defined.")
-    }
-
-    def graalvmPath = getGraalVMPath()
-    def javafxPath = setupJavaFXDependencies(platform, target)
+    def javaHome = validateJavaHome()
+    def graalvmHome = validateGraalvmHome()
+    def javafxStaticLibs = validateJavafxStaticLibs()
 
     def expected = System.getProperty("expected")
 
-    def argsList = ["${java_home}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxPath}/javafx.base.jar:${javafxPath}/javafx.graphics.jar:${javafxPath}/javafx.controls.jar:${javafxPath}/javafx.fxml.jar:" +
+    def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
+                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:${javafxStaticLibs}/javafx.fxml.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
-                    "-Dgraalvm=$graalvmPath",
+                    "-Dgraalvm=${graalvmHome}",
                     "-Dbundleslist=com.gluonhq.substrate.test.bundle",
                     "-Dreflectionlist=javafx.fxml.FXMLLoader,com.gluonhq.substrate.test.MainController,javafx.scene.control.Button,javafx.scene.control.Label",
             ]

--- a/test-project/helloFXML/build.gradle
+++ b/test-project/helloFXML/build.gradle
@@ -29,13 +29,14 @@ task runScript(type: Exec) {
 
     def javaHome = validateJavaHome()
     def graalvmHome = validateGraalvmHome()
-    def javafxStaticLibs = validateJavafxStaticLibs()
+    def javafxStaticSdk = validateJavafxStaticSdk()
 
     def expected = System.getProperty("expected")
 
     def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:${javafxStaticLibs}/javafx.fxml.jar:" +
+                    "-Dimagecp=${javafxStaticSdk}/lib/javafx.base.jar:${javafxStaticSdk}/lib/javafx.graphics.jar:${javafxStaticSdk}/lib/javafx.controls.jar:${javafxStaticHome}/lib/javafx.fxml.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
+                    "-Djavafxsdk=${javafxStaticSdk}",
                     "-Dgraalvm=${graalvmHome}",
                     "-Dbundleslist=com.gluonhq.substrate.test.bundle",
                     "-Dreflectionlist=javafx.fxml.FXMLLoader,com.gluonhq.substrate.test.MainController,javafx.scene.control.Button,javafx.scene.control.Label",

--- a/test-project/helloFXML/build.gradle
+++ b/test-project/helloFXML/build.gradle
@@ -34,7 +34,7 @@ task runScript(type: Exec) {
     def expected = System.getProperty("expected")
 
     def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxStaticSdk}/lib/javafx.base.jar:${javafxStaticSdk}/lib/javafx.graphics.jar:${javafxStaticSdk}/lib/javafx.controls.jar:${javafxStaticHome}/lib/javafx.fxml.jar:" +
+                    "-Dimagecp=${javafxStaticSdk}/lib/javafx.base.jar:${javafxStaticSdk}/lib/javafx.graphics.jar:${javafxStaticSdk}/lib/javafx.controls.jar:${javafxStaticSdk}/lib/javafx.fxml.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
                     "-Djavafxsdk=${javafxStaticSdk}",
                     "-Dgraalvm=${graalvmHome}",

--- a/test-project/helloGluon/build.gradle
+++ b/test-project/helloGluon/build.gradle
@@ -45,11 +45,12 @@ task runScript(type: Exec) {
 
     def javaHome = validateJavaHome()
     def graalvmHome = validateGraalvmHome()
-    def javafxStaticLibs = validateJavafxStaticLibs()
+    def javafxStaticSdk = validateJavafxStaticSdk()
 
     def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:" +
+                    "-Dimagecp=${javafxStaticSdk}/lib/javafx.base.jar:${javafxStaticSdk}/lib/javafx.graphics.jar:${javafxStaticSdk}/lib/javafx.controls.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
+                    "-Djavafxsdk=${javafxStaticSdk}",
                     "-Dgraalvm=${graalvmHome}"]
     if (target != null) {
         argsList += ["-DtargetProfile=$target"]

--- a/test-project/helloGluon/build.gradle
+++ b/test-project/helloGluon/build.gradle
@@ -40,22 +40,17 @@ javafx {
 
 mainClassName = "com.gluonhq.substrate.test.Main"
 
-def java_home = hasProperty('org.gradle.java.home') ? getProperty('org.gradle.java.home') : System.getenv('JAVA_HOME')
-
 task runScript(type: Exec) {
     dependsOn 'build'
 
-    if (java_home == null) {
-        throw new RuntimeException("java_home is not defined.")
-    }
+    def javaHome = validateJavaHome()
+    def graalvmHome = validateGraalvmHome()
+    def javafxStaticLibs = validateJavafxStaticLibs()
 
-    def graalvmPath = getGraalVMPath()
-    def javafxPath = setupJavaFXDependencies(platform, target)
-
-    def argsList = ["${java_home}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
-                    "-Dimagecp=${javafxPath}/javafx.base.jar:${javafxPath}/javafx.graphics.jar:${javafxPath}/javafx.controls.jar:" +
+    def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
+                    "-Dimagecp=${javafxStaticLibs}/javafx.base.jar:${javafxStaticLibs}/javafx.graphics.jar:${javafxStaticLibs}/javafx.controls.jar:" +
                             "${project.sourceSets.main.runtimeClasspath.filter{!it.name.contains('javafx')}.asPath}",
-                    "-Dgraalvm=$graalvmPath"]
+                    "-Dgraalvm=${graalvmHome}"]
     if (target != null) {
         argsList += ["-DtargetProfile=$target"]
     } else {

--- a/test-project/helloWorld/build.gradle
+++ b/test-project/helloWorld/build.gradle
@@ -1,4 +1,3 @@
-
 repositories {
     mavenLocal()
     mavenCentral()
@@ -16,21 +15,16 @@ dependencies {
 
 mainClassName = "com.gluonhq.substrate.test.Main"
 
-def java_home = hasProperty('org.gradle.java.home') ? getProperty('org.gradle.java.home') : System.getenv('JAVA_HOME')
-
 task runScript(type: Exec) {
-    if (java_home == null) {
-        throw new RuntimeException("java_home is not defined.")
-    }
-
-    def graalvmPath = getGraalVMPath()
+    def javaHome = validateJavaHome()
+    def graalvmHome = validateGraalvmHome()
 
     def skipsigning = System.getProperty("skipsigning")
     def expected = System.getProperty("expected")
 
-    def argsList = ["${java_home}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
+    def argsList = ["${javaHome}/bin/java", '-cp', "${project.configurations.substrate.asPath}",
                    "-Dimagecp=${project.sourceSets.main.runtimeClasspath.asPath}",
-                   "-Dgraalvm=$graalvmPath"]
+                   "-Dgraalvm=${graalvmHome}"]
     if (target != null) {
         argsList += ["-DtargetProfile=$target"]
     }


### PR DESCRIPTION
This PR moves the process of downloading the javafx static libraries from the gradle script inside the test-project folder to the CI scripts.

Fixes #493 