### PR TITLE
Remove invalid characters from appId

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -225,7 +225,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         logger.start();
 
         ProcessRunner run = new ProcessRunner(sdkPath.resolve("platform-tools").resolve("adb").toString(),
-                "shell", "monkey", "-p", projectConfiguration.getAppId(), "1");
+                "shell", "monkey", "-p", getAndroidPackageName(), "1");
         int processResult = run.runProcess("run");
         if (processResult != 0) throw new IOException("Application starting failed!");
 
@@ -410,8 +410,8 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         for (File jar : jars) {
             try (ZipFile zip = new ZipFile(jar)) {
                 Logger.logDebug("Scanning " + jar);
-                for (Enumeration e = zip.entries(); e.hasMoreElements(); ) {
-                    ZipEntry zipEntry = (ZipEntry) e.nextElement();
+                for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements(); ) {
+                    ZipEntry zipEntry = e.nextElement();
                     String name = zipEntry.getName();
                     if (!zipEntry.isDirectory() && name.startsWith(prefix)) {
                         Path classPath = targetFolder.resolve(name.substring(prefix.length()));
@@ -593,7 +593,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
             Path genManifest = androidPath.resolve(Constants.MANIFEST_FILE);
             Logger.logDebug("Copy " + Constants.MANIFEST_FILE + " to " + genManifest.toString());
             FileOps.copyResource("/native/android/AndroidManifest.xml", genManifest);
-            FileOps.replaceInFile(genManifest, "package='com.gluonhq.helloandroid'", "package='" + projectConfiguration.getAppId() + "'");
+            FileOps.replaceInFile(genManifest, "package='com.gluonhq.helloandroid'", "package='" + getAndroidPackageName() + "'");
             FileOps.replaceInFile(genManifest, "A HelloGraal", projectConfiguration.getAppName());
 
             Path androidResources = androidPath.resolve("res");
@@ -609,6 +609,18 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         }
         // use manifest and assets from src/android
         return targetSourcePath;
+    }
+
+    /**
+     * Takes the appId from the project configuration and translates it to an
+     * android package name friendly version. It does this by removing all
+     * characters that don't match the following characters: a-z, A-Z, 0-9,
+     * dot or underscore.
+     * @return
+     */
+    private String getAndroidPackageName() {
+        String appId = projectConfiguration.getAppId();
+        return appId.replaceAll("[^a-zA-Z0-9\\._]", "");
     }
 
     private static class BuildToolNotFoundException extends IOException {


### PR DESCRIPTION
The `appId` that is set in the project configuration is used as the package name in the default `AndroidManifest.xml`. This PR removes invalid characters from the `appId` before it is being used as the android package name.

Fixes #503 