### PR TITLE
Print the progress for a maximum of 10 times

### DIFF
--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -526,7 +526,9 @@ public class FileOps {
      * Prints the progress of a file download
      */
     private static final class ProgressDownloader {
-        
+
+        private int printPercentage = 0;
+
         public static void downloadFile(URL fileUrl, Path filePath) {
             new ProgressDownloader(fileUrl, filePath);
             System.out.println();
@@ -541,10 +543,13 @@ public class FileOps {
                 Logger.logSevere("Downloading failed: " + e.getMessage());
             }
         }
-
-        public void rbcProgressCallback(RBCWrapper rbc) {
-            System.out.print("\r" + String.format("Download progress: %.2f / %.2fM", toMB(rbc.readSoFar), toMB(rbc.expectedSize)));
-            System.out.flush();
+        
+        public void rbcProgressCallback(RBCWrapper rbc, double progress) {
+            if (((int)progress) >= printPercentage) {
+                printPercentage += 10;
+                System.out.print("\r" + String.format("Download progress: %.2f / %.2fM", toMB(rbc.readSoFar), toMB(rbc.expectedSize)));
+                System.out.flush();
+            }
         }
 
         private double toMB(long sizeInBytes) {
@@ -582,12 +587,12 @@ public class FileOps {
 
         public int read(ByteBuffer bb) throws IOException {
             int n;
-            // double progress;
+            double progress;
 
             if ((n = rbc.read(bb)) > 0) {
                 readSoFar += n;
-                // progress = expectedSize > 0 ? (double) readSoFar / (double) expectedSize * 100.0 : -1.0;
-                progressDownloader.rbcProgressCallback(this);
+                progress = expectedSize > 0 ? (double) readSoFar / (double) expectedSize * 100.0 : -1.0;
+                progressDownloader.rbcProgressCallback(this, progress);
             }
             return n;
         }


### PR DESCRIPTION
This PR reduces the number of updates/print statements while downloading, to a maximum of just 10.

For example:

```
[Fri Apr 10 01:26:10 IST 2020][INFO] Downloading JavaFX static libs...

Download progress: 0.01 / 24.94M
Download progress: 2.50 / 24.94M
Download progress: 4.99 / 24.94M
Download progress: 7.48 / 24.94M
Download progress: 9.98 / 24.94M
Download progress: 12.48 / 24.94M
Download progress: 14.97 / 24.94M
Download progress: 17.46 / 24.94M
Download progress: 19.95 / 24.94M
Download progress: 22.45 / 24.94M
Download progress: 24.94 / 24.94M
```

We can even print progress percentage instead of the size.

If we do not want to reduce the frequency of feedback to the user, then the easiest solution would be to embed a library like https://github.com/ctongfei/progressbar