### PR TITLE
Fixes for basic application on windows

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -280,7 +280,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     public boolean runUntilEnd() throws IOException, InterruptedException {
         Path appPath = Objects.requireNonNull(paths.getAppPath(),
                 "Application path can't be null");
-        String appName = Objects.requireNonNull(projectConfiguration.getAppName(),
+        String appName = Objects.requireNonNull(getLinkOutputName(),
                 "Application name can't be null");
         Path app = appPath.resolve(appName);
         if (!Files.exists(app)) {
@@ -796,8 +796,11 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     }
 
     List<String> getTargetSpecificLinkOutputFlags() {
-        String appName = projectConfiguration.getAppName();
-        return Arrays.asList("-o", getAppPath(appName));
+        return Arrays.asList("-o", getAppPath(getLinkOutputName()));
+    }
+
+    String getLinkOutputName() {
+        return projectConfiguration.getAppName();
     }
 
     protected List<String> getTargetNativeCodeExtensions() {

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -254,11 +254,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     }
 
     @Override
-    List<String> getTargetSpecificLinkOutputFlags() {
-        return Arrays.asList("-o", getAppPath(getLinkOutputName()));
-    }
-
-    private String getLinkOutputName() {
+    String getLinkOutputName() {
         String appName = projectConfiguration.getAppName();
         return "lib" + appName + ".so";
     }

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
 
     private static final List<String> javaWindowsLibs = Arrays.asList(
-            "msvcrt", "advapi32", "iphlpapi", "userenv", "ws2_32");
+            "advapi32", "iphlpapi", "userenv", "ws2_32");
     private static final List<String> staticJavaLibs = Arrays.asList(
             "j2pkcs11", "java", "net", "nio", "prefs", "sunec", "zip");
     private static final List<String> staticJvmLibs = Arrays.asList(

--- a/src/main/resources/native/windows/launcher.c
+++ b/src/main/resources/native/windows/launcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2019, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,14 +27,15 @@
  */
 #include <stdio.h>
 
-extern int *run_main(int argc, char* argv[]);
-const char* args[] = {"myapp"};
+extern int *run_main(int argc, const char* argv[]);
+int argc = 1;
+const char* argv[] = { "myapp" };
 
 int main() {
     #ifdef GVM_VERBOSE
       fprintf(stderr, "Main\n");
     #endif
-    (*run_main)(1, args);
+    (*run_main)(argc, argv);
 }
 
 // the following functions are used in Java 11 but not in 14


### PR DESCRIPTION
This includes the following fixes:

 - the run step now successfully finds the generated `.exe` file
 - use /MD flag for linker
 - remove unneeded linker library msvcrt.lib (implied by /MD)
 - add missing linker library: userenv.lib
 - eliminate warning when compiling launcher.c:

            warning C4090: 'function': different 'const' qualifiers