### PR TITLE
#543 Don’t print empty lines

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -187,8 +187,10 @@ static void *thread_func()
         if (buf[rdsz - 1] == '\n')
             --rdsz;
         buf[rdsz] = 0; /* add null-terminator */
-        __android_log_write(ANDROID_LOG_DEBUG, tag, buf);
-        // __android_log_print(ANDROID_LOG_DEBUG, tag, buf);
+        if (rdsz > 0) {
+            __android_log_write(ANDROID_LOG_DEBUG, tag, buf);
+            // __android_log_print(ANDROID_LOG_DEBUG, tag, buf);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Fixes #543, changing log from:

```
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): Loading ES2 native library ... prism_es2_monocle
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):   succeeded.
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): GLFactory using com.sun.prism.es2.MonocleGLFactory
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): In JNI_OnLoad_glass)monocle
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):
```
to:
```
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): Loading ES2 native library ... prism_es2_monocle
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887):   succeeded.
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): GLFactory using com.sun.prism.es2.MonocleGLFactory
[jue. abr. 23 21:18:24 CEST 2020][INFO] [SUB] D/GraalCompiled(28887): In JNI_OnLoad_glass)monocle
```
