### PR TITLE
pass CLI args to java main method

### DIFF
--- a/src/main/resources/native/linux/launcher.c
+++ b/src/main/resources/native/linux/launcher.c
@@ -27,14 +27,13 @@
  */
 #include <stdio.h>
 
-extern int *run_main(int argc, char* argv[]);
-const char* args[] = {"myapp"};
+extern int *run_main(int argc, const char* argv[]);
 
-int main() {
+int main(int argc, const char* argv[]) {
     #ifdef GVM_VERBOSE
       fprintf(stderr, "Main\n");
     #endif
-    (*run_main)(1, args);
+    (*run_main)(argc, argv);
 }
 
 // the following functions are used in Java 11 but not in 14

--- a/src/main/resources/native/macosx/launcher.c
+++ b/src/main/resources/native/macosx/launcher.c
@@ -29,9 +29,9 @@
 #include <pthread.h>
 #include <unistd.h>
 
-extern void outBox(int argc, char** argv);
+extern void outBox(int argc, const char** argv);
 
-int main(int argc, char** argv) {
+int main(int argc, const char** argv) {
     #ifdef GVM_VERBOSE
       fprintf(stderr, "Hello, JAVA main, argc = %d, argv = %p\n", argc, argv);
     #endif

--- a/src/main/resources/native/windows/launcher.c
+++ b/src/main/resources/native/windows/launcher.c
@@ -28,10 +28,8 @@
 #include <stdio.h>
 
 extern int *run_main(int argc, const char* argv[]);
-int argc = 1;
-const char* argv[] = { "myapp" };
 
-int main() {
+int main(int argc, const char* argv[]) {
     #ifdef GVM_VERBOSE
       fprintf(stderr, "Main\n");
     #endif


### PR DESCRIPTION
This PR fixes #566 making sure to pass down all CLI arguments to the java main method.