### PR TITLE
#588 Remove quarantine from root

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -461,7 +461,7 @@ public class InternalProjectConfiguration {
         if (graalvmHome == null || graalvmHome.isEmpty()) {
             return;
         }
-        String graalvmRoot = graalvmHome.endsWith("Contents/Home") ?
+        String graalvmRoot = graalvmHome.endsWith("/Contents/Home") ?
                 Path.of(graalvmHome).getParent().getParent().toString() :
                 graalvmHome;
         Logger.logDebug("Checking execution permissions for " + graalvmRoot);


### PR DESCRIPTION
Fixes #588.

If `GRAALVM_HOME` ends with `Contents/Home`, we remove quarantine starting from that path, but the parent folder remains with quarantine.

This PR removes quarantine from root GraalVM folder.
 