### PR TITLE
Fix for GraalVM version detection

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -100,7 +100,7 @@ public class InternalProjectConfiguration {
     }
 
     public Version getGraalVersion() throws IOException {
-        String pattern = "GraalVM .*(\\d\\d.\\d.\\d)";
+        String pattern = "GraalVM .*?(\\d\\d.\\d.\\d)";
         ProcessRunner graalJava;
         try {
             graalJava = new ProcessRunner(


### PR DESCRIPTION
Use non-greedy regex to match GraalVM version since current greedy regex matches Java version instead.