### PR TITLE
Use `RemoveSaturatedTypeFlows` by default on all platforms

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -89,7 +89,8 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             "-H:+AddAllCharsets",
             "-H:+ReportExceptionStackTraces",
             "-H:-DeadlockWatchdogExitOnTimeout",
-            "-H:DeadlockWatchdogInterval=0"
+            "-H:DeadlockWatchdogInterval=0",
+            "-H:+RemoveSaturatedTypeFlows"
     );
     private static final List<String> verboseNativeImageArguments = Arrays.asList(
             "-H:+PrintAnalysisCallTree",


### PR DESCRIPTION
This should speed up build times significantly.