### PR TITLE
First check if FileSystem already exists

### DIFF
--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -55,6 +55,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
@@ -158,7 +159,13 @@ public class FileOps {
         FileSystem fileSystem;
         try {
             URI resource = SubstrateDispatcher.class.getResource("").toURI();
-            fileSystem = FileSystems.newFileSystem(resource, Collections.<String, String>emptyMap());
+            try {
+                fileSystem = FileSystems.getFileSystem(resource);
+            } catch (FileSystemNotFoundException e) {
+                Logger.logInfo("FileSystem for resource " + resource + " not found. Trying to create a new FileSystem instead.");
+                fileSystem = FileSystems.newFileSystem(resource, Collections.<String, String>emptyMap());
+            }
+            Logger.logDebug("Created FileSystem for resource " + resource + ": " + fileSystem);
         } catch(URISyntaxException e) {
             throw new IOException(e.toString());
         }


### PR DESCRIPTION
Fixes #621 by first checking if the FileSystem can be found for the given resource URI. We only create a new FileSystem if it does not yet exist.