### PR TITLE
Release client plugins once Substrate release is successful

### DIFF
--- a/.github/scripts/release-plugins.sh
+++ b/.github/scripts/release-plugins.sh
@@ -3,8 +3,8 @@
 git config --global user.email "githubbot@gluonhq.com"
 git config --global user.name "Gluon Bot"
 
-CLIENT_MAVEN_REPO_SLUG=abhinayagarwal/client-maven-plugin
-CLIENT_GRADLE_REPO_SLUG=abhinayagarwal/client-gradle-plugin
+CLIENT_MAVEN_REPO_SLUG=gluonhq/client-maven-plugin
+CLIENT_GRADLE_REPO_SLUG=gluonhq/client-gradle-plugin
 
 cd $HOME
 git clone --depth 5 https://github.com/$CLIENT_MAVEN_REPO_SLUG
@@ -25,7 +25,7 @@ CLIENT_PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -Dfor
 # Commit and push tag
 git commit pom.xml -m "Release $CLIENT_PROJECT_VERSION"
 git tag $CLIENT_PROJECT_VERSION
-git push https://abhinayagarwal:$2@github.com/$CLIENT_MAVEN_REPO_SLUG $CLIENT_PROJECT_VERSION
+git push https://gluon-bot:$2@github.com/$CLIENT_MAVEN_REPO_SLUG $CLIENT_PROJECT_VERSION
 
 ###############################
 # 
@@ -41,4 +41,4 @@ sed -i "0,/^version '.*'/s//version '$CLIENT_PROJECT_VERSION'/" build.gradle
 # Commit and push tag
 git commit build.gradle -m "Release $CLIENT_PROJECT_VERSION"
 git tag $CLIENT_PROJECT_VERSION
-git push https://abhinayagarwal:$2@github.com/$CLIENT_GRADLE_REPO_SLUG $CLIENT_PROJECT_VERSION
+git push https://gluon-bot:$2@github.com/$CLIENT_GRADLE_REPO_SLUG $CLIENT_PROJECT_VERSION

--- a/.github/scripts/release-plugins.sh
+++ b/.github/scripts/release-plugins.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+git config --global user.email "githubbot@gluonhq.com"
+git config --global user.name "Gluon Bot"
+
+CLIENT_MAVEN_REPO_SLUG=abhinayagarwal/client-maven-plugin
+CLIENT_GRADLE_REPO_SLUG=abhinayagarwal/client-gradle-plugin
+
+cd $HOME
+git clone --depth 5 https://github.com/$CLIENT_MAVEN_REPO_SLUG
+git clone --depth 5 https://github.com/$CLIENT_GRADLE_REPO_SLUG
+
+###############################
+# 
+# Release client-maven-plugin
+#
+###############################
+cd $HOME/client-maven-plugin
+# Update Substrate
+mvn versions:set-property -Dproperty=substrate.version -DnewVersion=$1 -DgenerateBackupPoms=false
+git commit pom.xml -m "Update Substrate version to $1"
+# Remove SNAPSHOT
+mvn versions:set -DremoveSnapshot
+CLIENT_PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+# Commit and push tag
+git commit pom.xml -m "Release $CLIENT_PROJECT_VERSION"
+git tag $CLIENT_PROJECT_VERSION
+git push https://abhinayagarwal:$2@github.com/$CLIENT_MAVEN_REPO_SLUG $CLIENT_PROJECT_VERSION
+
+###############################
+# 
+# Release client-gradle-plugin
+#
+###############################
+cd $HOME/client-gradle-plugin
+# Update Substrate version
+sed -i "0,/com.gluonhq:substrate:.*/s//com.gluonhq:substrate:$1'/" build.gradle
+git commit build.gradle -m "Update Substrate version to $1"
+# Remove SNAPSHOT
+sed -i "0,/^version '.*'/s//version '$CLIENT_PROJECT_VERSION'/" build.gradle
+# Commit and push tag
+git commit build.gradle -m "Release $CLIENT_PROJECT_VERSION"
+git tag $CLIENT_PROJECT_VERSION
+git push https://abhinayagarwal:$2@github.com/$CLIENT_GRADLE_REPO_SLUG $CLIENT_PROJECT_VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,12 +44,12 @@ jobs:
           GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
 
       - name: Release Client plugins
-          if: steps.deploy.outputs.exit_code == 0
-          run: |
-            TAG=${GITHUB_REF/refs\/tags\//}
-            bash $GITHUB_WORKSPACE/.github/scripts/release-plugins.sh $TAG $PAT
-          env:
-            PAT: ${{ secrets.PAT }}
+        if: steps.deploy.outputs.exit_code == 0
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          bash $GITHUB_WORKSPACE/.github/scripts/release-plugins.sh $TAG $PAT
+        env:
+          PAT: ${{ secrets.PAT }}
 
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,14 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
 
+      - name: Release Client plugins
+          if: steps.deploy.outputs.exit_code == 0
+          run: |
+            TAG=${GITHUB_REF/refs\/tags\//}
+            bash $GITHUB_WORKSPACE/.github/scripts/release-plugins.sh $TAG $PAT
+          env:
+            PAT: ${{ secrets.PAT }}
+
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0
         run: |


### PR DESCRIPTION
After successfully releasing Substrate, we release both client-maven-plugin and client-gradle-plugin.

This PR has a dependency on gluonhq/client-maven-plugin#181