### PR TITLE
Don’t require LLVM toolchain on Android with LIR backend

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -444,8 +444,8 @@ public class InternalProjectConfiguration {
             // host doesn't use LLVM
             return;
         }
-        if (new Triplet(Constants.Profile.ANDROID).equals(triplet) && getBackend().equals(Constants.BACKEND_LIR)) {
-            // Android with LIR doesn't use LLVM
+        if (new Triplet(Constants.Profile.ANDROID).equals(triplet) && !Constants.BACKEND_LLVM.equals(getBackend())) {
+            // Android can use other backends
             return;
         }
         Path graalPath = getGraalPath();

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -441,6 +441,11 @@ public class InternalProjectConfiguration {
     public void canRunLLVM(Triplet triplet) throws IOException, InterruptedException {
         if (!new Triplet(Constants.Profile.IOS).equals(triplet) &&
                 !new Triplet(Constants.Profile.ANDROID).equals(triplet)) {
+            // host doesn't use LLVM
+            return;
+        }
+        if (new Triplet(Constants.Profile.ANDROID).equals(triplet) && getBackend().equals(Constants.BACKEND_LIR)) {
+            // Android with LIR doesn't use LLVM
             return;
         }
         Path graalPath = getGraalPath();


### PR DESCRIPTION
Fixes #625 