### PR TITLE
Always download latest release of GraalVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,23 +27,23 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          curl -v -u "gluon-bot:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+          curl -i -u "gluonteam:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
           export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
           wget ${GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL}
           tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
         env:
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GLUONTEAM_PAT }}
 
       - name: Install GraalVM (MacOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          curl -v -u "gluon-bot:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+          curl -i -u "gluonteam:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
           export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL="$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')"
           wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
           tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
         env:
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GLUONTEAM_PAT }}
 
       - name: Install linux JavaFX static libs (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,14 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
-          wget $GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL
+          curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+          grep browser_download_url releases.json
+          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64
+          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1
+          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
+          export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL="$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')"
+          echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
+          wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
           tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
 
       - name: Install linux JavaFX static libs (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,16 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          wget https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/20.2.0-dev-20200523_0158/graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz
+          export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+          wget $GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL
           tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
 
       - name: Install GraalVM (MacOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          wget https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/20.2.0-dev-20200523_0158/graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz
+          export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+          wget $GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL
           tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
 
       - name: Install linux JavaFX static libs (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,23 +27,23 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
-          wget $GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL
+          curl -v -u "gluon-bot:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+          export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+          wget ${GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL}
           tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
+        env:
+          PAT: ${{ secrets.PAT }}
 
       - name: Install GraalVM (MacOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p $HOME/graalvm && cd $HOME/graalvm
-          curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
-          grep browser_download_url releases.json
-          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64
-          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1
-          grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
-          export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL="$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')"
-          echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
+          curl -v -u "gluon-bot:$PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+          export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL="$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')"
           wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
           tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz -C $HOME/graalvm && cd $GITHUB_WORKSPACE
+        env:
+          PAT: ${{ secrets.PAT }}
 
       - name: Install linux JavaFX static libs (Linux)
         if: runner.os == 'Linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,14 @@ matrix:
       osx_image: xcode10.2
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
+        - curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+        - grep browser_download_url releases.json
+        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64
+        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1
+        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
         - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
-        - wget $GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL
+        - echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
+        - wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-darwin-x86_64-static.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ matrix:
             - libasound2-dev
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
-        - wget https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/20.2.0-dev-20200523_0158/graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz
+        - export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+        - wget $GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL
         - tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-linux-x86_64-static.zip
@@ -49,7 +50,8 @@ matrix:
       osx_image: xcode10.2
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
-        - wget https://github.com/graalvm/graalvm-ce-dev-builds/releases/download/20.2.0-dev-20200523_0158/graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz
+        - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+        - wget $GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL
         - tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin
         - wget https://download2.gluonhq.com/substrate/javafxstaticsdk/openjfx-15-latest-darwin-x86_64-static.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
             - libasound2-dev
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
-        - curl -v -u "gluon-bot:$GITHUB_PASSWORD" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+        - curl -i -u "gluonteam:$GLUONTEAM_PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
         - export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
         - wget $GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL
         - tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
@@ -52,14 +52,8 @@ matrix:
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
         - which curl
-        - curl -v -u "gluon-bot:$GITHUB_PASSWORD" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
-        - cat releases.json
-        - cat releases.json | grep browser_download_url
-        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64
-        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1
-        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
+        - curl -i -u "gluonteam:$GLUONTEAM_PAT" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
         - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
-        - echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-darwin && cd $HOME/javafx-static-libs-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,13 @@ matrix:
       osx_image: xcode10.2
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
+        - which curl
         - curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
-        - grep browser_download_url releases.json
-        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64
-        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1
-        - grep browser_download_url releases.json | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
+        - cat releases.json
+        - cat releases.json | grep browser_download_url
+        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64
+        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1
+        - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
         - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
         - echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ matrix:
             - libasound2-dev
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
-        - export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+        - curl -v -u "gluon-bot:$GITHUB_PASSWORD" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+        - export GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-linux-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
         - wget $GRAALVM_GITHUB_LINUX_AMD64_DOWNLOAD_URL
         - tar -xzvf graalvm-ce-java11-linux-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR
         - mkdir -p $HOME/javafx-static-libs-linux && cd $HOME/javafx-static-libs-linux
@@ -51,13 +52,13 @@ matrix:
       before_script:
         - mkdir -p $HOME/graalvm && cd $HOME/graalvm
         - which curl
-        - curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
+        - curl -v -u "gluon-bot:$GITHUB_PASSWORD" https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases > releases.json
         - cat releases.json
         - cat releases.json | grep browser_download_url
         - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64
         - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1
         - cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g'
-        - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(curl -s https://api.github.com/repos/graalvm/graalvm-ce-dev-builds/releases | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
+        - export GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL=$(cat releases.json | grep browser_download_url | grep graalvm-ce-java11-darwin-amd64 | head -n 1 | sed -e 's/.*\(https.*\)".*/\1/g')
         - echo ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - wget ${GRAALVM_GITHUB_DARWIN_AMD64_DOWNLOAD_URL}
         - tar -xzvf graalvm-ce-java11-darwin-amd64-20.2.0-dev.tar.gz && cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Fixes #616 by using the GitHub API to determine the download URL for the latest release of GraalVM.