### PR TITLE
Use subsystem windows

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -159,6 +159,9 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
         flags.add("/NODEFAULTLIB:libcmt.lib");
 
         if (useJavaFX) {
+            flags.add("/SUBSYSTEM:WINDOWS");
+            flags.add("/ENTRY:mainCRTStartup");
+
             flags.addAll(asListOfLibraryLinkFlags(javaFxWindowsLibs));
             flags.addAll(asListOfLibraryLinkFlags(staticJavaFxLibs));
             flags.addAll(asListOfWholeArchiveLinkFlags(staticJavaFxLibs));


### PR DESCRIPTION
Fixes #638 

Use subsystem windows and `mainCRTStartup` as the entry point, because the application is started from a `main()` method instead of a `WinMain()`.