### PR TITLE
Wait for a minute before we release the client plugins

### DIFF
--- a/.github/scripts/release-plugins.sh
+++ b/.github/scripts/release-plugins.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+echo "Wait for a minute for Maven Central to sync and make the artifact available to client plugins"
+counter=1
+while [ $counter -le 60 ]
+do
+  printf "."
+  sleep 1s
+((counter++))
+done
+
 git config --global user.email "githubbot@gluonhq.com"
 git config --global user.name "Gluon Bot"
 


### PR DESCRIPTION
One minute of wait time will give Maven Central time to sync and make Substrate artifact available to be used by the plugins.