### PR TITLE
Extract and add aar files to the Android project

### DIFF
--- a/src/main/resources/native/android/android_project/app/build.gradle
+++ b/src/main/resources/native/android/android_project/app/build.gradle
@@ -10,6 +10,7 @@ android {
 
     dependencies {
         implementation 'com.android.support:support-v4:27.1.1'
+        api fileTree(dir: '../libs', include: '*.aar')
         api fileTree(dir: '../libs', include: '*.jar')
     }
 

--- a/src/main/resources/native/android/android_project/app/src/main/AndroidManifest.xml
+++ b/src/main/resources/native/android/android_project/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.gluonhq.helloandroid' android:versionCode='1' android:versionName='1.0'>
     <supports-screens android:xlargeScreens="true"/>
     <uses-permission android:name="android.permission.INTERNET"/>
-    <!-- PERMISSIONS -->
     <application android:label='A HelloGraal' android:icon="@mipmap/ic_launcher">
         <activity android:name='com.gluonhq.helloandroid.MainActivity' android:configChanges="orientation|keyboardHidden">
              <intent-filter>

--- a/src/main/resources/native/android/android_project/app/src/main/AndroidManifest.xml
+++ b/src/main/resources/native/android/android_project/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.gluonhq.helloandroid' android:versionCode='1' android:versionName='1.0'>
     <supports-screens android:xlargeScreens="true"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- PERMISSIONS -->
     <application android:label='A HelloGraal' android:icon="@mipmap/ic_launcher">
         <activity android:name='com.gluonhq.helloandroid.MainActivity' android:configChanges="orientation|keyboardHidden">
              <intent-filter>


### PR DESCRIPTION
Follow-up of https://github.com/gluonhq/attach/pull/164

Using aar libraries with the dalvik classes and their own manifest removes the need of manually adding permissions, as the final project manifest results from merging all existing manifests.

CopyOtherDalvikClasses is still in use, in case there are third party jars that bundle precompiled dalvik classes, but not in an aar file.

Fixes #660