### PR TITLE
Bump gradlew version and set modulePath for javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ javadoc {
     options.addBooleanOption('html5', true)
     options.addBooleanOption('javafx', true)
     doFirst {
-        options.addStringOption('-module-path', classpath.asPath)
+        options.modulePath = classpath.flatten()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes #663 and #664 