### PR TITLE
Download clibraries if the CLibPath directory exists but is empty

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -382,7 +382,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     private void ensureClibs() throws IOException {
         Triplet target = projectConfiguration.getTargetTriplet();
         Path clibPath = getCLibPath();
-        if (!Files.exists(clibPath)) {
+        if (FileOps.isDirectoryEmpty(clibPath)) {
             String url = Strings.substitute(URL_CLIBS_ZIP, Map.of("osarch", target.getOsArch()));
             FileOps.downloadAndUnzip(url,
                     clibPath.getParent().getParent(),
@@ -390,7 +390,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
                     "clibraries",
                     target.getOsArch2());
         }
-        if (!Files.exists(clibPath)) {
+        if (FileOps.isDirectoryEmpty(clibPath)) {
             throw new IOException("No clibraries found for the required architecture in "+clibPath);
         }
         checkPlatformSpecificClibs(clibPath);

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -316,6 +316,18 @@ public class FileOps {
     }
 
     /**
+     * Checks and returns true if a Path is a directory and is empty
+     * @param path Path of the directory
+     */
+    public static boolean isDirectoryEmpty(Path path) {
+        try {
+            return Files.exists(path) && Files.isDirectory(path) && Files.list(path).findAny().isEmpty();
+        } catch (IOException e) {
+        }
+        return false;
+    }
+
+    /**
      * Recursively list files with spectified extension from directory
      * @param directory directory to be searched
      * @param extension extension by which to filter files

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -321,7 +321,7 @@ public class FileOps {
      */
     public static boolean isDirectoryEmpty(Path path) {
         try {
-            return Files.exists(path) && Files.isDirectory(path) && Files.list(path).findAny().isEmpty();
+            return !(Files.exists(path) && Files.isDirectory(path) && Files.list(path).findAny().isPresent());
         } catch (IOException e) {
         }
         return false;


### PR DESCRIPTION
Instead of just checking for the CLibPath, we should also check if the directory has files in it.