### PR TITLE
use objdump to check architecture of .a files on Linux.

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -31,6 +31,8 @@ import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.model.InternalProjectConfiguration;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.util.FileOps;
+import com.gluonhq.substrate.util.Logger;
+import com.gluonhq.substrate.util.ProcessRunner;
 import com.gluonhq.substrate.util.Version;
 import com.gluonhq.substrate.util.VersionParser;
 import com.gluonhq.substrate.util.linux.LinuxLinkerFlags;
@@ -45,7 +47,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 
 public class LinuxTargetConfiguration extends PosixTargetConfiguration {
 
@@ -263,5 +267,24 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
             return super.getLinker();
         }
         return "aarch64-linux-gnu-gcc";
+    }
+
+    @Override
+    Predicate<Path> getTargetSpecificNativeLibsFilter() {
+        return this::checkFileArchitecture;
+    }
+
+    private boolean checkFileArchitecture(Path path) {
+        try {
+            ProcessRunner pr = new ProcessRunner("objdump", "-f", path.toFile().getAbsolutePath());
+            int op = pr.runProcess("objdump");
+            if (op == 0) return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        Logger.logDebug("Ignore file " + path + " since objdump failed on it");
+        return false;
     }
 }

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-
 public class LinuxTargetConfiguration extends PosixTargetConfiguration {
 
     private static final Version COMPILER_MINIMAL_VERSION = new Version(6);
@@ -279,10 +278,8 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
             ProcessRunner pr = new ProcessRunner("objdump", "-f", path.toFile().getAbsolutePath());
             int op = pr.runProcess("objdump");
             if (op == 0) return true;
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+        } catch (IOException | InterruptedException e) {
+            Logger.logSevere("Unrecoverable error checking file "+path+": "+e);
         }
         Logger.logDebug("Ignore file " + path + " since objdump failed on it");
         return false;


### PR DESCRIPTION
If objdump sees the file has an unsupported architecture, it will return with 1.
In that case, we ignore the file (and don't copy it to the gvm/lib dir)