### PR TITLE
Use objdump on Android to check static native libraries

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -33,6 +33,7 @@ import com.gluonhq.substrate.model.ClassPath;
 import com.gluonhq.substrate.model.InternalProjectConfiguration;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.model.ReleaseConfiguration;
+import com.gluonhq.substrate.model.Triplet;
 import com.gluonhq.substrate.util.FileOps;
 import com.gluonhq.substrate.util.Logger;
 import com.gluonhq.substrate.util.ProcessRunner;
@@ -65,7 +66,7 @@ import static com.gluonhq.substrate.model.ReleaseConfiguration.DEFAULT_CODE_VERS
 
 public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
-    private static final String ANDROID_TRIPLET = "aarch64-linux-android";
+    private static final String ANDROID_TRIPLET = new Triplet(Constants.Profile.ANDROID).toString();
     private static final String ANDROID_MIN_SDK_VERSION = "21";
 
     private final String ndk;
@@ -93,7 +94,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
         this.sdk = fileDeps.getAndroidSDKPath().toString();
         this.ndk = fileDeps.getAndroidNDKPath().toString();
-        this.hostPlatformFolder = configuration.getHostTriplet().getOs() + "-" + Constants.ARCH_AMD64;
+        this.hostPlatformFolder = configuration.getHostTriplet().getOsArch();
 
         Path ldguess = Paths.get(this.ndk, "toolchains", "llvm", "prebuilt", hostPlatformFolder, "bin", "ld.lld");
         this.ldlld = Files.exists(ldguess) ? ldguess : null;
@@ -289,7 +290,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
             pr.showSevereMessage(false);
             int op = pr.runProcess("objdump");
             if (op == 0) {
-                return pr.getResponses().stream().anyMatch(line -> line.contains("architecture: " + Constants.ARCH_AARCH64));
+                return pr.getResponses().stream().anyMatch(line -> line.contains("architecture: " + projectConfiguration.getTargetTriplet().getArch()));
             }
         } catch (IOException | InterruptedException e) {
             Logger.logSevere("Unrecoverable error checking file " + path + ": " + e);

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -276,6 +276,7 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
     private boolean checkFileArchitecture(Path path) {
         try {
             ProcessRunner pr = new ProcessRunner("objdump", "-f", path.toFile().getAbsolutePath());
+            pr.showSevereMessage(false);
             int op = pr.runProcess("objdump");
             if (op == 0) return true;
         } catch (IOException | InterruptedException e) {

--- a/src/main/java/com/gluonhq/substrate/util/ProcessRunner.java
+++ b/src/main/java/com/gluonhq/substrate/util/ProcessRunner.java
@@ -60,6 +60,7 @@ public class ProcessRunner {
     private final List<String> passwords;
     private StringBuffer answer;
     private boolean info;
+    private boolean showSevere = true;
     private boolean logToFile;
     private Path processLogPath;
     private boolean interactive;
@@ -82,6 +83,16 @@ public class ProcessRunner {
      */
     public void setInfo(boolean info) {
         this.info = info;
+    }
+
+    /**
+     * When set to true, a message with Level.SEVERE will be logged in case
+     * the process fails.
+     * By default is true.
+     * @param showSevere a boolean that allows showing or not a severe message
+     */
+    public void showSevereMessage(boolean showSevere) {
+        this.showSevere = showSevere;
     }
 
     /**
@@ -197,7 +208,7 @@ public class ProcessRunner {
         int result = p.waitFor();
         logThread.join();
         Logger.logDebug("Result for " + processName + ": " + result);
-        if (result != 0) {
+        if (result != 0 && showSevere) {
             Logger.logSevere("Process " + processName + " failed with result: " + result);
         }
         if (logToFile || result != 0) {
@@ -236,7 +247,7 @@ public class ProcessRunner {
         boolean result = p.waitFor(timeout, TimeUnit.SECONDS);
         logThread.join();
         Logger.logDebug("Result for " + processName + ": " + result);
-        if (!result) {
+        if (!result && showSevere) {
             Logger.logSevere("Process " + processName + " failed with result: " + result);
         }
         if (logToFile || !result) {


### PR DESCRIPTION
Fixes #744, checking static native libraries.

Since we are testing with ProcessRunner, any invalid *.a file in the jar will log a severe message. To avoid this, I've added `showSevere` to ProcessRunner. In any case, the process result itself is logged to the usual log file, and if the process fails,  (due to invalid format for instance), a file is logged and the message is visible

```
[INFO] We will now compile your code for aarch64-linux-android. This may take some time.
[INFO] Logging process [objdump] to file: HelloFX/target/client/log/process-objdump-1597658045777.log
```