### PR TITLE
Increase default static JDK version to 11-ea+1 for ios/android

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -102,7 +102,7 @@ public class Constants {
     public static final String PROFILE_LINUX_AARCH64 = "linux-aarch64";
 
     // public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "15-ea+4";
-    public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "11-ea+0";
+    public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "11-ea+1";
     public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "15-ea+gvm22";
 
     /**


### PR DESCRIPTION
Fix for #749 