### PR TITLE
workaround for missing getdtablesize

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -176,6 +176,10 @@ void determineCPUFeatures()
     LOGE(stderr,  "\n\n\ndetermineCpuFeaures\n");
 }
 
+int getdtablesize() {
+    return sysconf(_SC_OPEN_MAX);
+}
+
 void JVM_NativePath() {
     fprintf(stderr, "We should never reach here (JVM_nativePath)\n");
 }


### PR DESCRIPTION
define getdtablesize
workaround for #761