### PR TITLE
JavaCPP properties in Android launcher

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -65,6 +65,9 @@ const char *origArgs[] = {
     "-Dmonocle.input.touchRadius=1",
     "-Dmonocle.input.traceEvents.verbose=true",
     "-Dprism.verbose=true",
+    "-Dorg.bytedeco.javacpp.platform=arm64-v8a",
+    "-Dorg.bytedeco.javacpp.platform.library.path=/lib",
+    "-Dorg.bytedeco.javacpp.pathsFirst=true",
     "-Xmx4g"};
 
 void registerMethodHandles(JNIEnv *aenv)


### PR DESCRIPTION
Hard-set the properties required for JavaCPP in the Android launcher
fix for #776