### PR TITLE
GA workflow should be triggered from new commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 5
+          persist-credentials: false
 
       - name: Setup Java 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
According to [this post](https://github.community/t/push-from-action-even-with-pat-does-not-trigger-action/17622/6), this change should fix #652 