### PR TITLE
Update ios-deploy formula and use local patch

### DIFF
--- a/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
@@ -104,9 +104,10 @@ public class Deploy {
                 checkPrerequisites();
             }
         } else {
-            // Check for ios-deploy version installed (it should be 1.10+)
+            // Check for ios-deploy version installed (it should be 1.11+)
             String version = ProcessRunner.runProcessForSingleOutput("ios-deploy version","ios-deploy", "-V");
-            if (version != null && !version.isEmpty() && (version.startsWith("1.8") || version.startsWith("1.9"))) {
+            if (version != null && !version.isEmpty() &&
+                    (version.startsWith("1.8") || version.startsWith("1.9") || version.startsWith("1.10"))) {
                 Logger.logDebug("ios-deploy version (" + version + ") is outdated");
                 uninstallIOSDeploy();
                 if (installIOSDeploy()) {

--- a/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
@@ -281,7 +281,9 @@ public class Deploy {
 
     private boolean installIOSDeploy() throws IOException, InterruptedException {
         Logger.logInfo("ios-deploy not found. It will be installed now");
+        Path tmpPatch = FileOps.copyResourceToTmp("/thirdparty/ios-deploy/lldbpatch.diff");
         Path tmpDeploy = FileOps.copyResourceToTmp("/thirdparty/ios-deploy/ios-deploy.rb");
+        FileOps.replaceInFile(tmpDeploy, "PATCH_PATH", "file://" + tmpPatch.toString());
 
         ProcessRunner runner = new ProcessRunner("brew", "install", "--HEAD", tmpDeploy.toString());
         if (runner.runProcess("ios-deploy") == 0) {

--- a/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/Deploy.java
@@ -108,7 +108,7 @@ public class Deploy {
             String version = ProcessRunner.runProcessForSingleOutput("ios-deploy version","ios-deploy", "-V");
             if (version != null && !version.isEmpty() &&
                     (version.startsWith("1.8") || version.startsWith("1.9") || version.startsWith("1.10"))) {
-                Logger.logDebug("ios-deploy version (" + version + ") is outdated");
+                Logger.logDebug("ios-deploy was outdated (version " + version + "), replacing with the latest version...");
                 uninstallIOSDeploy();
                 if (installIOSDeploy()) {
                     checkPrerequisites();

--- a/src/main/resources/thirdparty/ios-deploy/ios-deploy.rb
+++ b/src/main/resources/thirdparty/ios-deploy/ios-deploy.rb
@@ -1,19 +1,24 @@
 class IosDeploy < Formula
   desc "Install and debug iPhone apps from the command-line"
-  homepage "https://github.com/phonegap/ios-deploy"
-  url "https://github.com/ios-control/ios-deploy/archive/1.10.0.tar.gz"
-  sha256 "619176b0a78f631be169970a5afc9ec94b206d48ec7cb367bb5bf9d56b098290"
-  head "https://github.com/gluonhq/ios-deploy.git"
+  homepage "https://github.com/ios-control/ios-deploy"
+  url "https://github.com/ios-control/ios-deploy/archive/1.11.2.tar.gz"
+  sha256 "bca53cfb2a189e95cc8714d859a8821c3e6d5b9938ac74a7b3b69ea037e38244"
+  license all_of: ["GPL-3.0-or-later", "BSD-3-Clause"]
+  head "https://github.com/ios-control/ios-deploy.git"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "a368bb1c001f48f1c7354cdeb01fe67a4173489f9eadf6eab5b699caa5bacd7e" => :catalina
-    sha256 "6cfe843e5188f80b8c058da78acd1bab5260aea5fd4aa0a8685b8ff2e030aabc" => :mojave
-    sha256 "e4065110d50914cb2f1d6ef564f47a29ad3accd155b76e2a722cb0e40ed6764b" => :high_sierra
+    sha256 "2a08ef2f7fe4437a71b1ccfbe22e952fe6faa4850846417d09cb71d915f7b85d" => :catalina
+    sha256 "b90dde5c2b82daca41855e53d71fc3c21d29f06e3abbbc71de93ac9e6e961e5d" => :mojave
+    sha256 "93e988bd10d8b4419077ecbc9370569017c0a5241eeff8e89db7f8f47d530628" => :high_sierra
   end
 
-  depends_on :xcode => :build
-  depends_on :macos => :yosemite
+  depends_on xcode: :build
+
+  patch do
+     url "PATCH_PATH"
+     sha256 "c74520be482879bbef54fc775c8966cb2633847b5a489ecbd745c1eaaad1b7da"
+  end
 
   def install
     xcodebuild "-configuration", "Release", "SYMROOT=build"
@@ -21,8 +26,6 @@ class IosDeploy < Formula
     xcodebuild "test", "-scheme", "ios-deploy-tests", "-configuration", "Release", "SYMROOT=build"
 
     bin.install "build/Release/ios-deploy"
-    include.install "build/Release/libios_deploy.h"
-    lib.install "build/Release/libios-deploy.a"
   end
 
   test do

--- a/src/main/resources/thirdparty/ios-deploy/lldbpatch.diff
+++ b/src/main/resources/thirdparty/ios-deploy/lldbpatch.diff
@@ -1,0 +1,13 @@
+diff --git a/src/scripts/lldb.py b/src/scripts/lldb.py
+index 89feffb..9b3382a 100644
+--- a/src/scripts/lldb.py
++++ b/src/scripts/lldb.py
+@@ -103,7 +103,7 @@ def autoexit_command(debugger, command, result, internal_dict):
+     printBacktraceTime = time.time() + detectDeadlockTimeout if detectDeadlockTimeout > 0 else None
+     
+     # This line prevents internal lldb listener from processing STDOUT/STDERR messages. Without it, an order of log writes is incorrect sometimes
+-    debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
++    # debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
+ 
+     event = lldb.SBEvent()
+     


### PR DESCRIPTION
Fixes #781 by using the latest formula for ios-deploy, that allows installing from iOS-deploy master repo, and only requires a patch to the formula, to fix the issue of lack of logging when running `mvn -Pios client:run`. 