### PR TITLE
#813 list classpath deps relative to a temp folder

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -122,6 +122,7 @@ public class Constants {
     public static final String LOG_PATH = "log";
     public static final String APK_PATH = "apk";
     public static final String NATIVE_CODE_PATH = "native";
+    public static final String PATHING_JAR_DEPS_PATH = "deps";
 
 
 

--- a/src/main/java/com/gluonhq/substrate/model/ClassPath.java
+++ b/src/main/java/com/gluonhq/substrate/model/ClassPath.java
@@ -80,7 +80,7 @@ public class ClassPath {
      */
     public String mapToString(Function<String, String> mapper) {
         Objects.requireNonNull(mapper);
-        return asStream().map(mapper).collect(Collectors.joining(File.pathSeparator));
+        return asStream().map(mapper).distinct().collect(Collectors.joining(File.pathSeparator));
     }
 
     /**

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -151,7 +151,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
         compileRunner.addArg(getJniPlatformArg());
         compileRunner.addArg(Constants.NATIVE_IMAGE_ARG_CLASSPATH);
-        compileRunner.addArg(FileOps.createPathingJar(processedClasspath));
+        compileRunner.addArg(FileOps.createPathingJar(paths.getTmpPath(), processedClasspath));
         compileRunner.addArgs(projectConfiguration.getCompilerArgs());
         compileRunner.addArg(projectConfiguration.getMainClassName());
 

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -675,25 +675,60 @@ public class FileOps {
     }
 
     /**
-     * Shorten the Java classpath with a pathing jar
+     * Shorten the Java classpath with a pathing jar. This works by creating a temporary
+     * empty jar file where the full classpath is defined in its Class-Path entry in
+     * the manifest. All files on the classpath will be copied to the same temporary
+     * folder, while all directories will be resolved relatively against that temporary
+     * folder. The Class-Path entry will ultimately contain all classpath elements as a
+     * reference that is relative to the pathing jar.
+     *
      * @param classpath A string with the classpath of files that will be added to the
      *                 pathing jar Class-Path attribute
      * @return a String with the path to the created pathing jar
      * @throws IOException
      */
-    public static String createPathingJar(String classpath) throws IOException {
+    public static String createPathingJar(Path tmpPath, String classpath) throws IOException {
         Objects.requireNonNull(classpath);
+
+        String manifestClasspath = generateClasspathFromTemporaryFolder(tmpPath, classpath);
+        Logger.logDebug("Class-Path manifest entry for pathing jar: " + manifestClasspath);
+
         Manifest manifest = new Manifest();
         Attributes attributes = manifest.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        attributes.put(Attributes.Name.CLASS_PATH,
-                classpath.replaceAll(File.pathSeparator, " "));
-        File jarFile = File.createTempFile("classpathJar", ".jar");
+        attributes.put(Attributes.Name.CLASS_PATH, manifestClasspath);
+
+        File jarFile = tmpPath.resolve("classpathJar.jar").toFile();
         try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile), manifest)) {
             jos.putNextEntry(new ZipEntry("META-INF/"));
         }
         Logger.logDebug("Pathing jar created at " + jarFile);
         return jarFile.getAbsolutePath();
+    }
+
+    /**
+     * Copies all files in the classpath to the subfolder called <code>deps</code> under the provided
+     * temporary path. It then returns a space separated string containing each classpath entry as
+     * relative to the provided temporary path.
+     */
+    private static String generateClasspathFromTemporaryFolder(Path tmpPath, String classpath) {
+        Path depsPath = tmpPath.resolve("deps");
+
+        String[] classpathEntries = classpath.split(File.pathSeparator);
+
+        Stream<String> convertedDirectories = Arrays.stream(classpathEntries)
+                .map(Path::of)
+                .filter(Files::isDirectory)
+                .map(sourceDir -> tmpPath.toAbsolutePath().relativize(sourceDir).toString());
+
+        Stream<String> convertedFiles = Arrays.stream(classpathEntries)
+                .map(Path::of)
+                .filter(Files::isRegularFile)
+                .map(sourceFile -> copyFile(sourceFile, depsPath.resolve(sourceFile.getFileName())))
+                .map(destFile -> "deps/" + destFile.getFileName());
+
+        return Stream.concat(convertedDirectories, convertedFiles)
+                .collect(Collectors.joining(" "));
     }
 
     /**

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -690,6 +690,8 @@ public class FileOps {
     public static String createPathingJar(Path tmpPath, String classpath) throws IOException {
         Objects.requireNonNull(classpath);
 
+        Files.createDirectories(tmpPath);
+
         String manifestClasspath = generateClasspathFromTemporaryFolder(tmpPath, classpath);
         Logger.logDebug("Class-Path manifest entry for pathing jar: " + manifestClasspath);
 

--- a/src/main/java/com/gluonhq/substrate/util/FileOps.java
+++ b/src/main/java/com/gluonhq/substrate/util/FileOps.java
@@ -27,6 +27,7 @@
  */
 package com.gluonhq.substrate.util;
 
+import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.SubstrateDispatcher;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -709,12 +710,13 @@ public class FileOps {
     }
 
     /**
-     * Copies all files in the classpath to the subfolder called <code>deps</code> under the provided
-     * temporary path. It then returns a space separated string containing each classpath entry as
-     * relative to the provided temporary path.
+     * Copies all files in the classpath to a subfolder under the provided temporary path. The
+     * name of the subfolder is defined by {@link Constants#PATHING_JAR_DEPS_PATH}. It then
+     * returns a space separated string containing each classpath entry as relative to the
+     * provided temporary path.
      */
     private static String generateClasspathFromTemporaryFolder(Path tmpPath, String classpath) {
-        Path depsPath = tmpPath.resolve("deps");
+        Path depsPath = tmpPath.resolve(Constants.PATHING_JAR_DEPS_PATH);
 
         String[] classpathEntries = classpath.split(File.pathSeparator);
 
@@ -727,7 +729,7 @@ public class FileOps {
                 .map(Path::of)
                 .filter(Files::isRegularFile)
                 .map(sourceFile -> copyFile(sourceFile, depsPath.resolve(sourceFile.getFileName())))
-                .map(destFile -> "deps/" + destFile.getFileName());
+                .map(destFile -> Constants.PATHING_JAR_DEPS_PATH + File.separator + destFile.getFileName());
 
         return Stream.concat(convertedDirectories, convertedFiles)
                 .collect(Collectors.joining(" "));

--- a/src/test/java/com/gluonhq/substrate/model/ClassPathTests.java
+++ b/src/test/java/com/gluonhq/substrate/model/ClassPathTests.java
@@ -24,26 +24,32 @@ public class ClassPathTests {
     @Test
     public void testFilter() {
         var cp = new ClassPath("aaa:bbb:ccc");
-        assertIterableEquals(cp.filter("bbb"::equals), Collections.singletonList("bbb"));
+        assertIterableEquals(Collections.singletonList("bbb"), cp.filter("bbb"::equals));
     }
 
     @Test
     public void testMapToList() {
         var cp = new ClassPath("aaa:bbb:ccc");
-        assertIterableEquals(cp.mapToList( s -> "bbb".equals(s)? "xxx": s ), Arrays.asList("aaa","xxx","ccc"));
+        assertIterableEquals(Arrays.asList("aaa","xxx","ccc"), cp.mapToList( s -> "bbb".equals(s)? "xxx": s ));
     }
 
     @Test
     public void testMapToString() {
         var cp = new ClassPath("aaa:bbb:ccc");
-        assertEquals(cp.mapToString( s -> "bbb".equals(s)? "xxx": s ), "aaa:xxx:ccc");
+        assertEquals("aaa:xxx:ccc", cp.mapToString( s -> "bbb".equals(s)? "xxx": s ));
+    }
+
+    @Test
+    public void testMapToStringWithDuplicates() {
+        var cp = new ClassPath("aaa:bbb:ccc:bbb");
+        assertEquals("aaa:xxx:ccc", cp.mapToString( s -> "bbb".equals(s)? "xxx": s ));
     }
 
     @Test
     public void mapWithLibs() {
         var cp = new ClassPath("javafx-base:javafx-graphics");
         String newCp =  cp.mapWithLibs(Path.of("/aa/bb/"), "javafx-base", "javafx-graphics");
-        assertEquals(newCp, "/aa/bb/javafx-base.jar:/aa/bb/javafx-graphics.jar");
+        assertEquals("/aa/bb/javafx-base.jar:/aa/bb/javafx-graphics.jar", newCp);
     }
 
     @Test


### PR DESCRIPTION
Fixes #813

All classpath dependencies are first copied to a temporary folder. Then the pathing jar is created in the parent folder of that temporary folder. The Class-Path manifest entry of the pathing jar is then constructed by using the relative location of the copied dependencies. Any directories on the classpath are also resolved relatively against the location of the pathing jar.