### PR TITLE
Link with clang++ and libstdc++ on Android

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Gluon
+ * Copyright (c) 2019, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,6 @@ package com.gluonhq.substrate.target;
 
 import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.config.AndroidResolver;
-import com.gluonhq.substrate.config.ConfigResolver;
 import com.gluonhq.substrate.model.ClassPath;
 import com.gluonhq.substrate.model.InternalProjectConfiguration;
 import com.gluonhq.substrate.model.ProcessPaths;
@@ -109,7 +108,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         this.clang = Files.exists(clangguess) ? clangguess : null;
         Path clangplusguess = Paths.get(hostPlatformFolder, "bin", "clang++");
         this.clangplus = Files.exists(clangplusguess) ? clangplusguess : null;
-        
+
         projectConfiguration.setBackend(Constants.BACKEND_LIR);
 
         Path objdumpguess = Paths.get(hostPlatformFolder, ANDROID_TRIPLET, "bin", "objdump");

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -76,7 +76,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     private final String sdk;
     private final Path ldlld;
     private final Path clang;
-    private final Path clangplus;
+    private final Path clangpp;
     private final Path objdump;
     private final String hostPlatformFolder;
 
@@ -106,8 +106,8 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
         Path clangguess = Paths.get(hostPlatformFolder, "bin", "clang");
         this.clang = Files.exists(clangguess) ? clangguess : null;
-        Path clangplusguess = Paths.get(hostPlatformFolder, "bin", "clang++");
-        this.clangplus = Files.exists(clangplusguess) ? clangplusguess : null;
+        Path clangppguess = Paths.get(hostPlatformFolder, "bin", "clang++");
+        this.clangpp = Files.exists(clangppguess) ? clangppguess : null;
 
         projectConfiguration.setBackend(Constants.BACKEND_LIR);
 
@@ -131,7 +131,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
         // we override link as we need to do some checks first. If we have no clang in android_ndk, we should not start linking
         if (ndk == null) throw new IOException ("Can't find an Android NDK on your system. Set the environment property ANDROID_NDK");
         if (clang == null) throw new IOException ("You specified an android NDK, but it doesn't contain "+hostPlatformFolder+"/bin/clang");
-        if (clangplus == null) throw new IOException ("You specified an android NDK, but it doesn't contain "+hostPlatformFolder+"/bin/clang++");
+        if (clangpp == null) throw new IOException ("You specified an android NDK, but it doesn't contain "+hostPlatformFolder+"/bin/clang++");
         if (sdk == null) throw new IOException ("Can't find an Android SDK on your system. Set the environment property ANDROID_SDK");
 
         return super.link();
@@ -249,7 +249,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
     @Override
     String getLinker() {
-        return clangplus.toAbsolutePath().toString();
+        return clangpp.toAbsolutePath().toString();
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Deploying to Android 11 fails because of missing symbols. Adding `libstdc++` fixes it. This PR also provides support for C++ in native libraries. 

### Issue

<!--- The issue this PR addresses -->
Fixes #840 and #774

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)