### PR TITLE
add hard-coded path to static Java and JVM libs, at least on linux.

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -80,8 +80,8 @@ public class IosTargetConfiguration extends DarwinTargetConfiguration {
     }
 
     @Override
-    List<String> getTargetSpecificLinkLibraries() {
-        List<String> defaultLinkFlags = new ArrayList<>(super.getTargetSpecificLinkLibraries());
+    List<String> getTargetSpecificJavaLinkLibraries() {
+        List<String> defaultLinkFlags = new ArrayList<>(super.getTargetSpecificJavaLinkLibraries());
         defaultLinkFlags.add("-lstdc++");
         return defaultLinkFlags;
     }

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -134,7 +134,7 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
         Path graalClibsPath = getCLibPath();
         try {
             javaStaticLibPath = getStaticJDKLibPaths().get(0);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new RuntimeException("Fatal error, we have no static Java libraries, so we can't link with them.");
         }
         for (String lib : staticJavaLibs) {

--- a/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
@@ -98,7 +98,7 @@ public class MacOSTargetConfiguration extends DarwinTargetConfiguration {
     }
 
     @Override
-    List<String> getTargetSpecificLinkLibraries() {
+    List<String> getTargetSpecificJavaLinkLibraries() {
         List<String> targetLibraries = new ArrayList<>();
         targetLibraries.addAll(asListOfLibraryLinkFlags(staticJavaLibs));
         targetLibraries.addAll(asListOfLibraryLinkFlags(staticJvmLibs));

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -135,7 +135,7 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     }
 
     @Override
-    List<String> getTargetSpecificLinkLibraries() {
+    List<String> getTargetSpecificJavaLinkLibraries() {
         List<String> targetLibraries = new ArrayList<>();
 
         targetLibraries.addAll(asListOfLibraryLinkFlags(javaWindowsLibs));


### PR DESCRIPTION
Remove the JDK static libs path from the -L list, avoiding other libraries
to be unintentionally picked up from there (e.g. libharfbuzz).
This fixes #879
Fix for https://github.com/gluonhq/client-maven-plugin/issues/299
Fix for https://github.com/oracle/graal/issues/3213

<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #879

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)