### PR TITLE
893 remove ffi library from linker

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
@@ -50,7 +50,7 @@ public class MacOSTargetConfiguration extends DarwinTargetConfiguration {
             "java", "nio", "zip", "net", "prefs", "j2pkcs11", "fdlibm", "sunec", "extnet"
     );
     private static final List<String> staticJvmLibs = Arrays.asList(
-            "ffi", "jvm", "libchelper", "darwin"
+            "jvm", "libchelper", "darwin"
     );
     private static final List<String> staticJavaFxLibs = Arrays.asList(
             "glass", "javafx_font", "javafx_iio", "prism_es2"

--- a/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Gluon
+ * Copyright (c) 2019, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -45,7 +45,7 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     private static final List<String> staticJavaLibs = Arrays.asList(
             "j2pkcs11", "java", "net", "nio", "prefs", "fdlibm", "sunec", "zip");
     private static final List<String> staticJvmLibs = Arrays.asList(
-            "ffi", "jvm", "libchelper");
+            "jvm", "libchelper");
 
     private static final List<String> javaFxWindowsLibs = List.of(
             "comdlg32", "dwmapi", "gdi32", "imm32", "shell32",

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Gluon
+ * Copyright (c) 2019, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Adding the `ffi` library to the linker does not seem to be required at first sight.

### Issue

<!--- The issue this PR addresses -->
Fixes #893 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)