### PR TITLE
Set required CPUFeatures for iOS

### DIFF
--- a/src/main/resources/native/ios/AppDelegate.m
+++ b/src/main/resources/native/ios/AppDelegate.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Gluon
+ * Copyright (c) 2019, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -186,7 +186,24 @@ int startGVM(const char* userHome, const char* userTimeZone, const char* userLau
     return 0;
 }
 
-void determineCPUFeatures()
+typedef struct {
+  char fFP;
+  char fASIMD;
+  char fEVTSTRM;
+  char fAES;
+  char fPMULL;
+  char fSHA1;
+  char fSHA2;
+  char fCRC32;
+  char fLSE;
+  char fSTXRPREFETCH;
+  char fA53MAC;
+  char fDMBATOMICS;
+} CPUFeatures;
+
+void determineCPUFeatures(CPUFeatures* features)
 {
     fprintf(stderr, "\n\n\ndetermineCpuFeaures\n");
+    features->fFP = 1;
+    features->fASIMD = 1;
 }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
Use dummy method to set two CPU features that are recently required by GraalVM.

### Issue

<!--- The issue this PR addresses -->
Fixes #901

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)