### PR TITLE
Use libm.a on Linux instead of libm.so

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -103,7 +103,8 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
     private final String capLocation= "/native/linux-aarch64/cap/";
 
     private static final List<String> linuxfxSWlibs = Arrays.asList(
-            "-Wl,--whole-archive", "-lprism_sw", "-Wl,--no-whole-archive", "-lm");
+            "-Wl,--whole-archive", "-lprism_sw", "-Wl,--no-whole-archive",
+            "-l:libm.a");
 
     private final String sysroot;
 

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Gluon
+ * Copyright (c) 2019, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/util/linux/LinuxLinkerFlags.java
+++ b/src/main/java/com/gluonhq/substrate/util/linux/LinuxLinkerFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/util/linux/LinuxLinkerFlags.java
+++ b/src/main/java/com/gluonhq/substrate/util/linux/LinuxLinkerFlags.java
@@ -75,7 +75,7 @@ public class LinuxLinkerFlags {
         activeOf(debian("xtst", "libxtst-dev"),
                  fedora("xtst", "libXtst-devel")),
 
-        hardwired("-lm"),
+        hardwired("-l:libm.a"),
 
         activeOf(debian("gmodule-no-export-2.0", "libglib2.0-dev"),
                  fedora("gmodule-no-export-2.0", "glib2-devel"))


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #919 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)