### PR TITLE
Fail fast if JavaFX static path is set

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -87,7 +87,20 @@ public class InternalProjectConfiguration {
             getReleaseConfiguration().setSkipSigning(true);
         }
         setJavaStaticLibs(System.getProperty("javalibspath")); // this can be safely set even if null. Default will be used in that case
-        setJavaFXStaticSDK(System.getProperty("javafxsdk"));  // this can be safely set even if null. Default will be used in that case
+        String javafxStaticSdkPath = System.getenv("JAVAFX_STATIC_SDK_PATH");
+        if (javafxStaticSdkPath != null) {
+            Path lib = Path.of(javafxStaticSdkPath, "lib");
+            if (!Files.exists(lib) || !Files.isDirectory(lib)) {
+                throw new IllegalArgumentException("Error: " + lib + " is not a valid SDK path.\n" +
+                        "Make sure you provide a valid JAVAFX_STATIC_SDK_PATH or unset it");
+            }
+            if (!Files.exists(lib.resolve("javafx.base.jar")) ||
+                    !Files.exists(lib.resolve("javafx.graphics.jar"))) {
+                throw new IllegalArgumentException("Error: " + lib + " doesn't contain required JavaFX jars.\n" +
+                        "Make sure you provide a valid JAVAFX_STATIC_SDK_PATH or unset it");
+            }
+        }
+        setJavaFXStaticSDK(javafxStaticSdkPath);  // this can be safely set even if null. Default will be used in that case
         setInitBuildTimeList(Strings.split(System.getProperty("initbuildtimelist")));
 
         boolean useJavaFX = new ClassPath(config.getClasspath()).contains(s -> s.contains("javafx"));

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -722,6 +722,13 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         }
 
         return new ClassPath(classPath).mapWithLibs(fileDeps.getJavaFXSDKLibsPath(),
+                s -> s.replace("-", "."),
+                p -> {
+                    if (!Files.exists(p)) {
+                        throw new IllegalArgumentException("Error: " + p + " not found. Cannot compile.");
+                    }
+                    return true;
+                },
                 "javafx-base", "javafx-graphics", "javafx-controls", "javafx-fxml", "javafx-media", "javafx-web");
     }
 

--- a/src/test/java/com/gluonhq/substrate/model/ClassPathTests.java
+++ b/src/test/java/com/gluonhq/substrate/model/ClassPathTests.java
@@ -1,8 +1,10 @@
 package com.gluonhq.substrate.model;
 
+import com.gluonhq.substrate.util.FileOps;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +12,8 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClassPathTests {
@@ -48,8 +52,63 @@ public class ClassPathTests {
     @Test
     public void mapWithLibs() {
         var cp = new ClassPath("javafx-base:javafx-graphics");
-        String newCp =  cp.mapWithLibs(Path.of("/aa/bb/"), "javafx-base", "javafx-graphics");
+        String newCp = cp.mapWithLibs(Path.of("/aa/bb/"), "javafx-base", "javafx-graphics");
         assertEquals("/aa/bb/javafx-base.jar:/aa/bb/javafx-graphics.jar", newCp);
+    }
+
+    @Test
+    public void mapWithLibsAndMap() {
+        var cp = new ClassPath("javafx-base:javafx-graphics");
+        String newCp = cp.mapWithLibs(Path.of("/aa/bb/"),
+                s -> s.replace("-", "."),
+                null,
+                "javafx-base", "javafx-graphics");
+        assertEquals("/aa/bb/javafx.base.jar:/aa/bb/javafx.graphics.jar", newCp);
+    }
+
+    @Test
+    public void mapWithLibsAndTest() {
+        var cp = new ClassPath("javafx-base:javafx-graphics");
+        String newCp = cp.mapWithLibs(Path.of("/aa/bb/"),
+                null,
+                p -> Files.exists(p),
+                "javafx-base", "javafx-graphics");
+        assertEquals("javafx-base:javafx-graphics", newCp);
+    }
+
+    @Test
+    public void mapWithLibsAndThrowException() {
+        var cp = new ClassPath("javafx-base:javafx-graphics");
+        assertThrows(IllegalArgumentException.class, () -> cp.mapWithLibs(Path.of("/aa/bb/"),
+                null,
+                p -> {
+                    if (!Files.exists(p)) {
+                        throw new IllegalArgumentException("Error: " + p + " not found");
+                    }
+                    return true;
+                },
+                "javafx-base", "javafx-graphics"));
+    }
+
+    @Test
+    public void mapWithLibsMapTest() throws IOException {
+        Path resourcePath = Files.createTempDirectory("substrate-tests").resolve("substrate-test.jar");
+        FileOps.copyResource("/substrate-test.jar", resourcePath);
+        assertNotNull(resourcePath);
+        assertTrue(Files.exists(resourcePath));
+
+        var cp = new ClassPath("substrate=test");
+        String newCp = cp.mapWithLibs(resourcePath.getParent(),
+                s -> s.replace("=", "-"),
+                p -> {
+                    if (!Files.exists(p)) {
+                        throw new IllegalArgumentException("Error: " + p + " not found");
+                    }
+                    return true;
+                },
+                "substrate=test");
+        assertEquals(resourcePath.toString(), newCp);
+        Files.deleteIfExists(resourcePath);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
Fail fast if JavaFX static path is set but it is not valid, and also, when set, allow mapping and check files exist. 
A few more tests are included.

### Issue

<!--- The issue this PR addresses -->
Fixes #922

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)