### PR TITLE
Add release-drafter GA to create a Github Release draft

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+exclude-labels:
+  - 'housekeeping'
 template: |
   ## What’s Changed
   $CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,3 +94,10 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Draft release
+        if: runner.os == 'Linux' && github.ref == 'refs/heads/master'
+        # Drafts your next Release notes as Pull Requests are merged into "master"
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Automates release notes from PR. Each time a PR is merged into the master branch, it is added to the release notes in Github Release.

Example: https://github.com/abhinayagarwal/test-release-drafter/releases

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)