### PR TITLE
Add dummy AWT methods to Android launcher

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -209,7 +209,7 @@ void JVM_RawMonitorExit() {
     fprintf(stderr, "We should never reach here (JVM_RawMonitorExit)\n");
 }
 
-// AWT
+// AWT: Provide dummy methods for unresolved references to libawt
 void Java_java_awt_Toolkit_initIDs() {
     fprintf(stderr, "We should never reach here (Java_java_awt_Toolkit_initIDs)\n");
 }

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -208,3 +208,16 @@ void JVM_RawMonitorEnter() {
 void JVM_RawMonitorExit() {
     fprintf(stderr, "We should never reach here (JVM_RawMonitorExit)\n");
 }
+
+// AWT
+void Java_java_awt_Toolkit_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_Toolkit_initIDs)\n");
+}
+
+void JNI_OnLoad_awt() {
+    fprintf(stderr, "We should never reach here (JNI_OnLoad_awt)\n");
+}
+
+void JNI_OnLoad_awt_headless() {
+    fprintf(stderr, "We should never reach here (JNI_OnLoad_awt_headless)\n");
+}

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -209,7 +209,9 @@ void JVM_RawMonitorExit() {
     fprintf(stderr, "We should never reach here (JVM_RawMonitorExit)\n");
 }
 
-// AWT: Provide dummy methods for unresolved references to libawt
+// AWT: GraalVM native-image explicitly adds (unresolved) references to libawt
+// so we need to make sure the JNI_OnLoad symbols are there.
+
 void Java_java_awt_Toolkit_initIDs() {
     fprintf(stderr, "We should never reach here (Java_java_awt_Toolkit_initIDs)\n");
 }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #970 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)