### PR TITLE
Use JavaFX JS SDK version as internal version

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -107,6 +107,7 @@ public class Constants {
 
     public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "11-ea+10";
     public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "17-ea+14";
+    public static final String DEFAULT_JAVAFX_JS_SDK_VERSION  = "18-internal+0-2021-09-02-165800";
     public static final String DEFAULT_SYSROOT_VERSION  = "20210424";
 
     /**
@@ -155,7 +156,6 @@ public class Constants {
     public static final String ANDROID_PROJECT_NAME = "android_project";
 
     public static final String META_INF_SUBSTRATE_WEB = "META-INF/substrate/web/";
-    public static final String WEB_NATIVE_FOLDER = "/native/web/";
     public static final String WEB_AOT_CLASSIFIER = "bck2brwsr";
     public static final String WEB_AOT_VERSION = "0.51";
     public static final String WEB_INDEX_HTML = "index.html";

--- a/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
@@ -271,6 +271,9 @@ public class WebTargetConfiguration extends AbstractTargetConfiguration {
             protected String version(File a) {
                 String artifact = artifacts.get(a);
                 if (artifact != null) {
+                    if ("org.openjfx".equals(groupId(a)) && classifier(a) != null) {
+                        return Constants.DEFAULT_JAVAFX_JS_SDK_VERSION;
+                    }
                     return artifact.split(":")[2];
                 }
                 return null;


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #996 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)