### PR TITLE
Add more dummy methods to the Android launcher

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -227,3 +227,139 @@ void JNI_OnLoad_awt() {
 void JNI_OnLoad_awt_headless() {
     fprintf(stderr, "We should never reach here (JNI_OnLoad_awt_headless)\n");
 }
+
+void JNI_OnLoad_javajpeg() {
+    fprintf(stderr, "We should never reach here (JNI_OnLoad_javajpeg)\n");
+}
+
+void JNI_OnLoad_lcms() {
+    fprintf(stderr, "We should never reach here (JNI_OnLoad_lcms)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_disposeReader() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_disposeReader)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_initJPEGImageReader() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_initJPEGImageReader)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_initReaderIDs() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_initReaderIDs)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_resetReader() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_resetReader)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_disposeWriter() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_disposeWriter)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_initJPEGImageWriter() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_initJPEGImageWriter)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_initWriterIDs() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_initWriterIDs)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_resetWriter() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_resetWriter)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_setDest() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_setDest)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeImage() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeImage)\n");
+}
+
+void Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeTables() {
+    fprintf(stderr, "We should never reach here (Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeTables)\n");
+}
+
+void Java_java_awt_image_BufferedImage_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_BufferedImage_initIDs)\n");
+}
+
+void Java_java_awt_image_ColorModel_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_ColorModel_initIDs)\n");
+}
+
+void Java_java_awt_image_IndexColorModel_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_IndexColorModel_initIDs)\n");
+}
+
+void Java_java_awt_image_Raster_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_Raster_initIDs)\n");
+}
+
+void Java_java_awt_image_SampleModel_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_SampleModel_initIDs)\n");
+}
+
+void Java_java_awt_image_SinglePixelPackedSampleModel_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_java_awt_image_SinglePixelPackedSampleModel_initIDs)\n");
+}
+
+void Java_sun_awt_image_ByteComponentRaster_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_sun_awt_image_ByteComponentRaster_initIDs)\n");
+}
+
+void Java_sun_awt_image_BytePackedRaster_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_sun_awt_image_BytePackedRaster_initIDs)\n");
+}
+
+void Java_sun_awt_image_IntegerComponentRaster_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_sun_awt_image_IntegerComponentRaster_initIDs)\n");
+}
+
+void Java_sun_awt_image_ShortComponentRaster_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_sun_awt_image_ShortComponentRaster_initIDs)\n");
+}
+
+void Java_sun_java2d_Disposer_initIDs() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_Disposer_initIDs)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_colorConvert() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_colorConvert)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_createNativeTransform() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_createNativeTransform)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_getProfileDataNative() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_getProfileDataNative)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_getProfileID() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_getProfileID)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_getProfileSizeNative() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_getProfileSizeNative)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_getTagNative() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_getTagNative)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_initLCMS() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_initLCMS)\n");
+}
+
+void Java_sun_java2d_cmm_lcms_LCMS_loadProfileNative() {
+    fprintf(stderr, "We should never reach here (Java_sun_java2d_cmm_lcms_LCMS_loadProfileNative)\n");
+}


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

This is a follow up to https://github.com/gluonhq/substrate/pull/971 and https://github.com/gluonhq/substrate/pull/972.

I made a minimal Android app with FXGL, the game engine which uses JavaFX. It turns out that GraalVM Native Image
adds many more unresolved references when compiling FXGL. I added the dummy methods for them to launcher.c.

With these changes my minimal app works  but I wonder if this is a good approach. All the methods I added have
something to do with image handling. What if, when I start to write a more complex app, GraalVM Native Image will
start adding even more references?

Here's my app: https://github.com/makingthematrix/scalaonandroid/tree/main/HelloFXGL

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)