### PR TITLE
Update javafx static version to latest version 18-ea+2

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -106,7 +106,7 @@ public class Constants {
     public static final String PROFILE_WEB = "web";
 
     public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "11-ea+10";
-    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "17-ea+14";
+    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "17";
     public static final String DEFAULT_JAVAFX_JS_SDK_VERSION  = "18-internal+0-2021-09-02-165800";
     public static final String DEFAULT_SYSROOT_VERSION  = "20210424";
 

--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -106,7 +106,7 @@ public class Constants {
     public static final String PROFILE_WEB = "web";
 
     public static final String DEFAULT_JAVA_STATIC_SDK_VERSION  = "11-ea+10";
-    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "17";
+    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "18-ea+2";
     public static final String DEFAULT_JAVAFX_JS_SDK_VERSION  = "18-internal+0-2021-09-02-165800";
     public static final String DEFAULT_SYSROOT_VERSION  = "20210424";
 


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Update JavaFX static version to latest ea release i.e. 18-ea+2

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)