### PR TITLE
Use correct path for clibs for the linux-aarch64 target

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/Triplet.java
+++ b/src/main/java/com/gluonhq/substrate/model/Triplet.java
@@ -195,24 +195,27 @@ public class Triplet {
 
     /**
      *
-     * On iOS/iOS-sim and Android returns a string with a valid version for clibs,
-     * for other OSes returns an empty string
+     * On iOS/iOS-sim, Android and Linux-AArch64, it returns a string
+     * with a valid version for clibs, for other OSes returns an empty string
      * @return
      */
     public String getClibsVersion() {
-        if (OS_IOS.equals(getOs()) || OS_ANDROID.equals(getOs())) {
+        if (OS_IOS.equals(getOs()) || OS_ANDROID.equals(getOs()) ||
+                (OS_LINUX.equals(getOs()) && ARCH_AARCH64.equals(getArch()))) {
             return "-ea+" + Constants.DEFAULT_CLIBS_VERSION;
         }
         return "";
     }
     /**
      *
-     * On iOS/iOS-sim and Android returns a string with a valid path for clibs,
-     * for other OSes returns an empty string
+     * On iOS/iOS-sim, Android and Linux-AArch64, it returns a string
+     * with a valid path for clibs, for other OSes returns an empty string
+     *
      * @return
      */
     public String getClibsVersionPath() {
-        if (OS_IOS.equals(getOs()) || OS_ANDROID.equals(getOs())) {
+        if (OS_IOS.equals(getOs()) || OS_ANDROID.equals(getOs()) ||
+                (OS_LINUX.equals(getOs()) && ARCH_AARCH64.equals(getArch()))) {
             return Constants.DEFAULT_CLIBS_VERSION;
         }
         return "";


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1004 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)