### PR TITLE
Use more recent version of bck2brwsr.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.googlecode.plist:dd-plist:1.22'
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.49'
     implementation 'org.graalvm.nativeimage:svm:21.1.0'
-    implementation 'org.apidesign.bck2brwsr:aot:0.51'
+    implementation 'org.apidesign.bck2brwsr:aot:0.53'
 
     testImplementation gradleTestKit()
     testImplementation "org.junit.jupiter:junit-jupiter-api:$jUnitVersion"

--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -158,7 +158,7 @@ public class Constants {
 
     public static final String META_INF_SUBSTRATE_WEB = "META-INF/substrate/web/";
     public static final String WEB_AOT_CLASSIFIER = "bck2brwsr";
-    public static final String WEB_AOT_VERSION = "0.51";
+    public static final String WEB_AOT_VERSION = "0.53";
     public static final String WEB_INDEX_HTML = "index.html";
 
     public static final String META_INF_SUBSTRATE_CONFIG = "META-INF/substrate/config/";

--- a/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
@@ -57,7 +57,7 @@ import static com.gluonhq.substrate.Constants.WEB_INDEX_HTML;
 public class WebTargetConfiguration extends AbstractTargetConfiguration {
 
     public static final List<String> WEB_AOT_DEPENDENCIES = List.of(
-            "com.gluonhq:webscheduler:1.0.6",
+            "com.gluonhq:webscheduler:1.0.7",
             "com.gluonhq.compat:javadate:1.1",
             "com.gluonhq.compat:javafunctions:1.1",
             "com.gluonhq.compat:javanio:1.2",


### PR DESCRIPTION
This implies using a more recent version of uongl, part of webscheduler, which uses bck2brwsr as well.
Fix for #1011
