### PR TITLE
Add missing entitlements to codesign

### DIFF
--- a/src/main/java/com/gluonhq/substrate/util/macos/CodeSigning.java
+++ b/src/main/java/com/gluonhq/substrate/util/macos/CodeSigning.java
@@ -120,6 +120,9 @@ public class CodeSigning {
         }
 
         ProcessRunner appRunner = new ProcessRunner("codesign", "--options", "runtime", "--force", "--sign", identity.getSha1());
+        if (entitlementsPath != null) {
+            appRunner.addArgs("--entitlements", entitlementsPath.toString());
+        }
         if (projectConfiguration.isVerbose()) {
             appRunner.addArg("--verbose");
         }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Entitlements, if present, are needed to sign both executable (already done) and .app itself (missing).

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)