### PR TITLE
Refactor iOSTarget and Deploy

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -229,6 +229,12 @@ public class IosTargetConfiguration extends DarwinTargetConfiguration {
 
     @Override
     public boolean install() throws IOException, InterruptedException {
+        if (projectConfiguration.getReleaseConfiguration().isSkipSigning()) {
+            // Without signing app can't be installed on device
+            // Simply exit and do nothing
+            return true;
+        }
+
         Path app = getAndValidateAppPath();
 
         Deploy deploy = new Deploy(paths.getTmpPath().resolve(iosCheck));
@@ -248,6 +254,12 @@ public class IosTargetConfiguration extends DarwinTargetConfiguration {
 
     @Override
     public boolean runUntilEnd() throws IOException, InterruptedException {
+        if (projectConfiguration.getReleaseConfiguration().isSkipSigning()) {
+            // Without signing app can't be installed or run on device
+            // Simply exit and do nothing
+            return true;
+        }
+
         Path app = getAndValidateAppPath();
 
         Deploy deploy = new Deploy(paths.getTmpPath().resolve(iosCheck));

--- a/src/main/java/com/gluonhq/substrate/util/ios/CodeSigning.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/CodeSigning.java
@@ -301,7 +301,7 @@ public class CodeSigning {
         return true;
     }
 
-    private boolean verifyCodesign(Path target) throws IOException, InterruptedException {
+    public static boolean verifyCodesign(Path target) throws IOException, InterruptedException {
         Logger.logDebug("Validating codesign...");
         ProcessRunner runner = new ProcessRunner("codesign", "--verify", "-vvvv", target.toAbsolutePath().toString());
         if (runner.runTimedProcess("verify", 5)) {

--- a/src/main/java/com/gluonhq/substrate/util/ios/InfoPlist.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/InfoPlist.java
@@ -308,7 +308,7 @@ public class InfoPlist {
                 "Please check the src/ios/Default-info.plist file and make sure CFBundleExecutable key exists");
     }
 
-    static String getBundleId(Path plist, String appId) {
+    public static String getBundleId(Path plist, String appId) {
         if (plist == null) {
             Objects.requireNonNull(appId, "AppId can't be null if plist is not provided");
             return appId;

--- a/src/test/java/com/gluonhq/substrate/IOSTest.java
+++ b/src/test/java/com/gluonhq/substrate/IOSTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +60,7 @@ class IOSTest {
     private Deploy getDeploy() {
         if (deploy == null) {
             try {
-                deploy = new Deploy();
+                deploy = new Deploy(Files.createTempDirectory("substrate-tests").resolve("ios/check"));
             } catch (IOException | InterruptedException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Refactor iOSTargetConfiguration: link doesn't sign, package creates .app and .ipa, installs is mandatory and doesn't launch the app, nativerun doesn't install, and launches an installed app.

Changes in Deploy allow calling separately install and run. 
Caching `ios-deploy` location and prerequisites speeds up process of repetitive calls to install/run.

### Issue

<!--- The issue this PR addresses -->
Fixes #1064

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)