### PR TITLE
use hard paths to static JDK libs, avoid having the static JDK libs p…

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -828,6 +828,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
      * linker when creating images for the specific target.
      */
     String getLinkLibraryOption(String libname) {
+        if (libname.startsWith("/")) return libname;
         return "-l" + libname;
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/LinuxTargetConfiguration.java
@@ -223,8 +223,14 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
 
     @Override
     List<String> getStaticJavaLibs() {
+        Path javaStaticLibPath;
+        try {
+            javaStaticLibPath = getStaticJDKLibPaths().get(0);
+        } catch (IOException ex) {
+            throw new RuntimeException ("No static java libs found, cannot continue");
+        }
         return staticJavaLibs.stream()
-                .map(lib -> ":lib" + lib + ".a")
+                .map(lib -> javaStaticLibPath.resolve("lib" + lib + ".a").toString())
                 .collect(Collectors.toList());
     }
 
@@ -237,11 +243,6 @@ public class LinuxTargetConfiguration extends PosixTargetConfiguration {
     @Override
     protected List<Path> getLinkerLibraryPaths() throws IOException {
         List<Path> linkerLibraryPaths = new ArrayList<>();
-        try {
-            linkerLibraryPaths.add(getStaticJDKLibPaths().get(0));
-        } catch (Exception ex) {
-            throw new RuntimeException("Fatal error, we have no static Java libraries, so we can't link with them.");
-        }
         linkerLibraryPaths.add(getCLibPath());
         if (projectConfiguration.isUseJavaFX()) {
             linkerLibraryPaths.add(fileDeps.getJavaFXSDKLibsPath());


### PR DESCRIPTION
use hard paths to static JDK libs, avoid having the static JDK libs path in the -L search path as this might pull in unwanted libs (e.g. libharfbuzz.a)

Closes #1069 