### PR TITLE
Fix unsupported operation exception on iOS target

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -114,12 +114,12 @@ public class IosTargetConfiguration extends DarwinTargetConfiguration {
 
     @Override
     List<String> getTargetSpecificCCompileFlags() {
-        List<String> flags = Arrays.asList("-xobjective-c",
+        List<String> flags = new ArrayList<>(Arrays.asList("-xobjective-c",
                 "-arch", getTargetArch(),
                 "-mios-version-min=11.0",
                 "-I" + projectConfiguration.getGraalPath().resolve("include").toString(),
                 "-I" + projectConfiguration.getGraalPath().resolve("include").resolve("darwin").toString(),
-                "-isysroot", getSysroot());
+                "-isysroot", getSysroot()));
         if (!projectConfiguration.usesJDK11()) {
             flags.add("-DGVM_17");
         }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue
After #1083, there is an issue in IosTargetConfiguration::getTargetSpecificCCompileFlags:

```
[INFO] We will now compile your code for arm64-apple-ios. This may take some time.
java.lang.UnsupportedOperationException
        at java.base/java.util.AbstractList.add(AbstractList.java:153)
        at java.base/java.util.AbstractList.add(AbstractList.java:111)
        at com.gluonhq.substrate.target.IosTargetConfiguration.getTargetSpecificCCompileFlags(IosTargetConfiguration.java:124)
        at com.gluonhq.substrate.target.AbstractTargetConfiguration.compileAdditionalSources(AbstractTargetConfiguration.java:318)
        at com.gluonhq.substrate.target.AbstractTargetConfiguration.compile(AbstractTargetConfiguration.java:134)

```

<!--- The issue this PR addresses -->
This PR prevents such exception.

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)