### PR TITLE
Set LIR backend by default

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/IosTargetConfiguration.java
@@ -80,9 +80,8 @@ public class IosTargetConfiguration extends DarwinTargetConfiguration {
     public IosTargetConfiguration(ProcessPaths paths, InternalProjectConfiguration configuration ) {
         super(paths, configuration);
 
-        // for now default to LLVM
         if (!isSimulator() && projectConfiguration.getBackend() == null) {
-            projectConfiguration.setBackend(Constants.BACKEND_LLVM);
+            projectConfiguration.setBackend(Constants.BACKEND_LIR);
         }
 
         if (isSimulator() && projectConfiguration.usesJDK11()) {


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue
Set LIR backend in case there is no backend set (which could be done via env var GRAALVM_COMPILER_BACKEND)

<!--- The issue this PR addresses -->
Fixes #1095 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)