### PR TITLE
add 'linkerArgs' config option

### DIFF
--- a/src/main/java/com/gluonhq/substrate/ProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/ProjectConfiguration.java
@@ -58,6 +58,7 @@ public class ProjectConfiguration {
     private List<String> reflectionList = Collections.emptyList();
     private List<String> jniList = Collections.emptyList();
     private List<String> compilerArgs = Collections.emptyList();
+    private List<String> linkerArgs = Collections.emptyList();
     private List<String> runtimeArgs = Collections.emptyList();
 
     private String appId;
@@ -234,6 +235,19 @@ public class ProjectConfiguration {
      */
     public void setCompilerArgs(List<String> compilerArgs) {
         this.compilerArgs = compilerArgs;
+    }
+
+    public List<String> getLinkerArgs() {
+        return linkerArgs;
+    }
+
+    /**
+     * Sets an additional list of linker arguments that will be added to the linker command "as is",
+     * without any form of validation on these arguments.
+     * @param linkerArgs a list of additional linker arguments.
+     */
+    public void setLinkerArgs(List<String> linkerArgs) {
+        this.linkerArgs = linkerArgs;
     }
 
     /**

--- a/src/main/java/com/gluonhq/substrate/ProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/ProjectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Gluon
+ * Copyright (c) 2019, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -380,6 +380,11 @@ public class InternalProjectConfiguration {
                 .orElse(Collections.emptyList());
     }
 
+    public List<String> getLinkerArgs() {
+        return Optional.ofNullable(publicConfig.getLinkerArgs())
+                .orElse(Collections.emptyList());
+    }
+
     public List<String> getInitBuildTimeList() {
         return initBuildTimeList;
     }

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Gluon
+ * Copyright (c) 2019, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -223,6 +223,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
 
         linkRunner.addArgs(getLinkerLibraryPathFlags());
         linkRunner.addArgs(getNativeLibsLinkFlags());
+        linkRunner.addArgs(projectConfiguration.getLinkerArgs());
         linkRunner.setInfo(true);
         linkRunner.setLogToFile(true);
         int result = linkRunner.runProcess("link");

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Gluon
+ * Copyright (c) 2019, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

This adds a configuration option to externally configure additional linker flags

### Issue

<!--- The issue this PR addresses -->
Fixes https://github.com/gluonhq/substrate/issues/1101

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)