### PR TITLE
Fix missing symbol for Android with JDK11

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -189,6 +189,7 @@ void Java_java_net_AbstractPlainDatagramSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_AbstractPlainSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_DatagramPacket_init() {}
 #else
+// dummy symbols only for JDK11
 void Java_java_net_PlainDatagramSocketImpl_send0() {}
 #endif
 

--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -188,6 +188,8 @@ int getdtablesize() {
 void Java_java_net_AbstractPlainDatagramSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_AbstractPlainSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_DatagramPacket_init() {}
+#else
+void Java_java_net_PlainDatagramSocketImpl_send0() {}
 #endif
 
 // AWT: GraalVM native-image explicitly adds (unresolved) references to libawt

--- a/src/main/resources/native/ios/AppDelegate.m
+++ b/src/main/resources/native/ios/AppDelegate.m
@@ -267,4 +267,7 @@ void determineCPUFeatures(CPUFeatures* features)
 void Java_java_net_AbstractPlainDatagramSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_AbstractPlainSocketImpl_isReusePortAvailable0() {}
 void Java_java_net_DatagramPacket_init() {}
+#else
+// dummy symbols only for JDK11
+void Java_java_net_PlainDatagramSocketImpl_send0() {}
 #endif


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1109 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)