### PR TITLE
Use new clibs version

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -110,7 +110,7 @@ public class Constants {
     public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "18-ea+11";
     public static final String DEFAULT_JAVAFX_JS_SDK_VERSION  = "18-internal+0-2021-09-02-165800";
     public static final String DEFAULT_SYSROOT_VERSION  = "20210424";
-    public static final String DEFAULT_CLIBS_VERSION  = "26";
+    public static final String DEFAULT_CLIBS_VERSION  = "27";
     public static final String DEFAULT_JAVASDK_PATH = "staticjdk";
     public static final String DEFAULT_JAVASDK_PATH11 = "labs-staticjdk";
 

--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Gluon
+ * Copyright (c) 2019, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/resources/native/ios/JvmFuncsFallbacks.c
+++ b/src/main/resources/native/ios/JvmFuncsFallbacks.c
@@ -508,11 +508,6 @@ JNIEXPORT jobject JNICALL JVM_GetSystemPackages(JNIEnv *env) {
     return NULL;
 }
 
-JNIEXPORT jobject JNICALL JVM_GetTemporaryDirectory(JNIEnv *env) {
-    (*env)->FatalError(env, "JVM_GetTemporaryDirectory called:  Unimplemented");
-    return NULL;
-}
-
 JNIEXPORT jobject JNICALL JVM_GetVmArguments(JNIEnv *env) {
     (*env)->FatalError(env, "JVM_GetVmArguments called:  Unimplemented");
     return NULL;


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->
This [commit](https://github.com/oracle/graal/commit/4694c9e5158a82d396b5ec2a61a011936eb0caa9) modifies `foundation.c` and this other [commit](https://github.com/oracle/graal/commit/716fbdcb3e5da98d30fe868e5319784cf7aefe80) modifies `JvmFuncs.c`, so a new build of clibs was needed.

Therefore, clibs version 27 for iOS, iOS-Sim, Android and Linux-Aarch64 has been built.

Also the latter commit provides support for `JVM_GetTemporaryDirectory`, so the dummy symbol can be removed.

### Issue

<!--- The issue this PR addresses -->
Fixes #1128

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)