### PR TITLE
Add MACOS_AARCH64 profile

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
         LINUX, // (x86_64-linux-linux)
         LINUX_AARCH64, // (aarch64-linux-linux or aarch64-linux-gnu)
         MACOS, // (x86_64-apple-darwin)
+        MACOS_AARCH64, // (aarch64-apple-darwin)
         WINDOWS, // (x86_64-windows-windows)
         IOS,   // (aarch64-apple-ios)
         IOS_SIM,   // (x86_64-apple-ios)

--- a/src/main/java/com/gluonhq/substrate/model/Triplet.java
+++ b/src/main/java/com/gluonhq/substrate/model/Triplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Gluon
+ * Copyright (c) 2019, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,7 +56,11 @@ public class Triplet {
      */
     public static Triplet fromCurrentOS() throws IllegalArgumentException {
         if (isMacOSHost()) {
-           return new Triplet(Constants.Profile.MACOS);
+            if (isAarch64Arch()) {
+                return new Triplet(Constants.Profile.MACOS_AARCH64);
+            } else {
+                return new Triplet(Constants.Profile.MACOS);
+            }
         } else if (isLinuxHost()) {
             if (isAarch64Arch()) {
                 return new Triplet(Constants.Profile.LINUX_AARCH64);
@@ -118,6 +122,11 @@ public class Triplet {
                 break;
             case MACOS:
                 this.arch = ARCH_AMD64;
+                this.vendor = VENDOR_APPLE;
+                this.os = OS_DARWIN;
+                break;
+            case MACOS_AARCH64:
+                this.arch = ARCH_AARCH64;
                 this.vendor = VENDOR_APPLE;
                 this.os = OS_DARWIN;
                 break;

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -388,7 +388,14 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
                 }
                 return "IOS_AARCH64";
             case Constants.OS_DARWIN:
-                return graalVM221 ? "MACOS_AMD64" : "DARWIN_AMD64";
+                switch (arch) {
+                    case Constants.ARCH_AMD64:
+                        return graalVM221 ? "MACOS_AMD64" : "DARWIN_AMD64";
+                    case Constants.ARCH_AARCH64:
+                        return "MACOS_AARCH64";
+                    default:
+                        throw new IllegalArgumentException("No support yet for " + os + ":" + arch);
+                }
             case Constants.OS_WINDOWS:
                 return "WINDOWS_AMD64";
             case Constants.OS_ANDROID:


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1131

- Requires latest dev version from GraalVM with support for macOS AArch64
- Requires new version of JavaFX static to include config files (but these can be added manually in the meantime) 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)