### PR TITLE
Change default value from 1 to 2

### DIFF
--- a/src/main/resources/native/android/c/launcher.c
+++ b/src/main/resources/native/android/c/launcher.c
@@ -66,7 +66,7 @@ const char *origArgs[] = {
     "-Dcom.sun.javafx.gestures.rotate=true",
     "-Dcom.sun.javafx.gestures.scroll=true",
     "-Djavafx.verbose=false",
-    "-Dmonocle.input.touchRadius=1",
+    "-Dmonocle.input.touchRadius=2",
     "-Dmonocle.input.traceEvents.verbose=false",
     "-Dprism.verbose=true",
     "-Xmx4g"};


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Changes the value of `-Dmonocle.input.touchRadius` from 1 to 2.

<!--- The issue this PR addresses -->
Fixes #1183

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)