### PR TITLE
Fixed issue #1185

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WebTargetConfiguration.java
@@ -236,7 +236,7 @@ public class WebTargetConfiguration extends AbstractTargetConfiguration {
                     Path path = a.toPath();
                     int m2Index = 0;
                     while (!".m2".equals(path.getName(m2Index++).toString())) { }
-                    String groupId = path.subpath(m2Index + 1, path.getNameCount() - 3).toString().replaceAll(File.separator, ".");
+                    String groupId = path.subpath(m2Index + 1, path.getNameCount() - 3).toString().replace(File.separator, ".");
                     String artifactId = path.getName(path.getNameCount() - 3).toString();
                     String version = path.getName(path.getNameCount() - 2).toString();
                     String artifact = groupId + ":" + artifactId + ":" + version;


### PR DESCRIPTION
Fixed issue #1185 where gluon for web would not build on a windows pc.
Java methods `replaceAll` and `replace` do the same thing, though `replaceAll` uses RegEx.
Method crashes on a windows pc because "\\" is an invalid RegEx as the file separator for windows is a backslash