### PR TITLE
Allow internal JDK builds to be used with Substrate.

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -657,7 +657,8 @@ public class InternalProjectConfiguration {
         if (responses == null || responses.isEmpty()) {
             throw new IOException("Couldn't determine GraalVM's Java version");
         }
-        Matcher m = r.matcher(responses.get(0));
+        String realVersion = responses.get(0).replaceAll("-internal", "");
+        Matcher m = r.matcher(realVersion);
         if (!m.find()) {
             throw new IOException("Couldn't determine GraalVM's Java version for " + responses.get(0));
         }


### PR DESCRIPTION
When building the JDK from sources, by default the version name will contain the "internal-" String. This patch allows JDK versions containing this "internal-" String to be used as sources for GraalVM builds

Fix for #1201

<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)