### PR TITLE
Add required code so that plugins can request to build a static library.

### DIFF
--- a/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
+++ b/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
@@ -510,4 +510,20 @@ public class SubstrateDispatcher {
         config.setSharedLibrary(true);
         return targetConfiguration.createSharedLib();
     }
+
+    /**
+     * This method builds a static library that can be used by third
+     * party projects, considering it contains one or more entry points.
+     *
+     * Static entry points, callable from C, can be created with the {@code @CEntryPoint}
+     * annotation.
+     *
+     * @throws Exception
+     */
+    public boolean nativeStaticLibrary() throws Exception {
+        Logger.logInfo(logTitle("STATIC LIBRARY TASK"));
+        config.setStaticLibrary(true);
+        return targetConfiguration.createStaticLib();
+    }
+
 }

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -66,6 +66,7 @@ public class InternalProjectConfiguration {
     private boolean enableCheckHash = true;
     private boolean usesJDK11 = false;
     private boolean sharedLibrary = false;
+    private boolean staticLibrary = false;
 
     private String backend;
     private List<String> initBuildTimeList;
@@ -333,6 +334,14 @@ public class InternalProjectConfiguration {
 
     public void setSharedLibrary(boolean sharedLibrary) {
         this.sharedLibrary = sharedLibrary;
+    }
+
+    public boolean isStaticLibrary() {
+        return staticLibrary;
+    }
+
+    public void setStaticLibrary(boolean staticLibrary) {
+        this.staticLibrary = staticLibrary;
     }
 
     public Triplet getTargetTriplet() {

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -184,11 +184,6 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
         return validateCompileResult(result);
     }
 
-    /**
-    * Links a previously created objectfile with the required
-    * dependencies into a native executable.
-    * @return true if linking succeeded, false otherwise
-    */
     @Override
     public boolean link() throws IOException, InterruptedException {
         compileAdditionalSources();

--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -201,7 +201,9 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             new IllegalArgumentException(
                     "Linking failed, since there is no objectfile named " + objectFilename + " under " + gvmPath.toString())
         );
-
+        if (projectConfiguration.isStaticLibrary()) {
+            return createStaticLib();
+        }
         ProcessRunner linkRunner = new ProcessRunner(getLinker());
 
         Path gvmAppPath = gvmPath.resolve(appName);
@@ -314,6 +316,17 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
      */
     @Override
     public boolean createSharedLib() throws IOException, InterruptedException {
+        return true;
+    }
+
+    /**
+     * Creates a static library
+     * @return true if the process succeeded or false if the process failed
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Override
+    public boolean createStaticLib() throws IOException, InterruptedException {
         return true;
     }
 

--- a/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
@@ -39,6 +39,11 @@ public interface TargetConfiguration {
      */
     boolean compile() throws Exception;
 
+    /**
+    * Links a previously created objectfile with the required
+    * dependencies into a native executable or library
+    * @return true if linking succeeded, false otherwise
+    */
     boolean link() throws IOException, InterruptedException;
 
     /**

--- a/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/TargetConfiguration.java
@@ -91,4 +91,13 @@ public interface TargetConfiguration {
      * @throws InterruptedException
      */
     boolean createSharedLib() throws IOException, InterruptedException;
+
+    /**
+     * Creates a static library
+     * @return true if the process succeeded or false if the process failed
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    boolean createStaticLib() throws IOException, InterruptedException;
+
 }


### PR DESCRIPTION
This is currently a no-op.
Having this PR integrated allows the plugins to add the static lib option as well.

Fix #1203

<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)