### PR TITLE
Parse HTML to XML

### DIFF
--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/NativeWebView.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/NativeWebView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/NativeWebView.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/NativeWebView.java
@@ -81,7 +81,8 @@ public class NativeWebView {
                     @Override
                     public void onPageFinished(WebView view, final String url) {
                         Log.v(TAG, "Page finished: " + url);
-                        NativeWebView.this.webView.evaluateJavascript("document.documentElement.innerHTML", new ValueCallback<String>() {
+                        // convert HTML into XML before it can be parsed into DOM
+                        NativeWebView.this.webView.evaluateJavascript("new XMLSerializer().serializeToString(document)", new ValueCallback<String>() {
                             @Override
                             public void onReceiveValue(String s) {
                                 Properties p = new Properties();


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

Web content (HTML) shouldn't be parsed by Java (`com.sun.org.apache.xerces.internal.parsers.DOMParser`) which only processes XML.

Therefore, an straightforward fix for this issue is parsing first HTML into XML.

### Issue

<!--- The issue this PR addresses -->
Fixes #1210 

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)