### PR TITLE
Bump JavaFX version to 21-ea+11.1

### DIFF
--- a/src/main/java/com/gluonhq/substrate/Constants.java
+++ b/src/main/java/com/gluonhq/substrate/Constants.java
@@ -108,7 +108,7 @@ public class Constants {
 
     public static final String DEFAULT_JAVA_STATIC_SDK_VERSION = "18-ea+prep18-8";
     public static final String DEFAULT_JAVA_STATIC_SDK_VERSION11 = "11-ea+10";
-    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "21-ea+9.1";
+    public static final String DEFAULT_JAVAFX_STATIC_SDK_VERSION  = "21-ea+11.1";
     public static final String DEFAULT_JAVAFX_JS_SDK_VERSION  = "18-internal+0-2021-09-02-165800";
     public static final String DEFAULT_SYSROOT_VERSION  = "20210424";
     public static final String DEFAULT_CLIBS_VERSION  = "27";


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)