### PR TITLE
handle OpenJDK aligned GraalVM versions

### DIFF
--- a/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
+++ b/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Gluon
+ * Copyright (c) 2019, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
+++ b/src/main/java/com/gluonhq/substrate/SubstrateDispatcher.java
@@ -40,6 +40,7 @@ import com.gluonhq.substrate.target.WindowsTargetConfiguration;
 import com.gluonhq.substrate.util.Logger;
 import com.gluonhq.substrate.util.ProcessRunner;
 import com.gluonhq.substrate.util.Strings;
+import com.gluonhq.substrate.util.Version;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -378,8 +379,8 @@ public class SubstrateDispatcher {
             System.out.println("Configuration: " + this.config);
         }
 
-        this.config.checkGraalVMVersion();
-        this.config.checkGraalVMJavaVersion();
+        Version javaVersion = this.config.checkGraalVMJavaVersion();
+        this.config.checkGraalVMVersion(javaVersion);
         this.config.checkGraalVMVendor();
 
         Triplet targetTriplet = config.getTargetTriplet();

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -474,25 +474,39 @@ public class InternalProjectConfiguration {
      * Check if the GraalVM provided by the configuration is supported
      * @throws IOException if the GraalVM version is older than the minimum supported version
      */
-    public void checkGraalVMVersion() throws IOException {
-        Version graalVersion = getGraalVersion();
-        if (graalVersion.compareTo(new Version(Constants.GRAALVM_MIN_VERSION)) < 0) {
-            throw new IOException("Current GraalVM version (" + graalVersion + ") not supported.\n" +
-                    "Please upgrade to " + Constants.GRAALVM_MIN_VERSION + " or higher");
+    public void checkGraalVMVersion(Version javaVersion) throws IOException {
+        System.out.println("hello world");
+        if (isOldGraalVMVersioningScheme(javaVersion)) {
+            Version graalVersion = getGraalVersion();
+            if (graalVersion.compareTo(new Version(Constants.GRAALVM_MIN_VERSION)) < 0) {
+                throw new IOException("Current GraalVM version (" + graalVersion + ") not supported.\n" +
+                        "Please upgrade to " + Constants.GRAALVM_MIN_VERSION + " or higher");
+            }
         }
+    }
+
+    public boolean isOldGraalVMVersioningScheme(Version javaVersion) {
+        if (javaVersion.getMajor() == 17) {
+            // JDK 17 versions before 17.0.7 used the old versioning scheme
+            return javaVersion.compareTo(new Version(17, 0, 7)) < 0;
+        }
+        // all other releases before JDK 20 use the old versioning
+        // staring from JDK 20, all releases follow the new versioning
+        return javaVersion.getMajor() < 20;
     }
 
     /**
      * Check if the GraalVM's java provided by the configuration is supported
      * @throws IOException if the GraalVM's java version is older than the minimum supported version
      */
-    public void checkGraalVMJavaVersion() throws IOException {
+    public Version checkGraalVMJavaVersion() throws IOException {
         Version javaVersion = getGraalVMJavaVersion();
         if (javaVersion.compareTo(new Version(Constants.GRAALVM_JAVA_MIN_VERSION)) < 0) {
             throw new IOException("Current GraalVM's java version (" + javaVersion + ") not supported.\n" +
                     "Please upgrade to " + Constants.GRAALVM_JAVA_MIN_VERSION + " or higher");
         }
         usesJDK11 = javaVersion.getMajor() == 11;
+        return javaVersion;
     }
 
     /**

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Gluon
+ * Copyright (c) 2019, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -475,7 +475,6 @@ public class InternalProjectConfiguration {
      * @throws IOException if the GraalVM version is older than the minimum supported version
      */
     public void checkGraalVMVersion(Version javaVersion) throws IOException {
-        System.out.println("hello world");
         if (isOldGraalVMVersioningScheme(javaVersion)) {
             Version graalVersion = getGraalVersion();
             if (graalVersion.compareTo(new Version(Constants.GRAALVM_MIN_VERSION)) < 0) {

--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -480,6 +480,8 @@ public class InternalProjectConfiguration {
             if (graalVersion.compareTo(new Version(Constants.GRAALVM_MIN_VERSION)) < 0) {
                 throw new IOException("Current GraalVM version (" + graalVersion + ") not supported.\n" +
                         "Please upgrade to " + Constants.GRAALVM_MIN_VERSION + " or higher");
+            } else {
+                // TODO: check the GraalVM version whenever Constants.GRAALVM_MIN_VERSION is bumped and uses the new versioning system
             }
         }
     }

--- a/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
+++ b/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
@@ -1,0 +1,47 @@
+package com.gluonhq.substrate.model;
+
+import com.gluonhq.substrate.ProjectConfiguration;
+import com.gluonhq.substrate.util.Version;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.gradle.internal.impldep.org.junit.Assert.assertEquals;
+
+class InternalProjectConfigurationTest {
+
+    @ParameterizedTest
+    @MethodSource("versioningSchemeParameters")
+    void testIsOldGraalVMVersioningScheme(String version, boolean usesOldScheme) {
+        Version javaVersion = new Version(version);
+        InternalProjectConfiguration config = new InternalProjectConfiguration(new ProjectConfiguration("", ""));
+        assertEquals(usesOldScheme, config.isOldGraalVMVersioningScheme(javaVersion));
+    }
+
+    static Stream<Arguments> versioningSchemeParameters() {
+        return Stream.of(
+                Arguments.of("11.0.0", true),
+                Arguments.of("12.0.0", true),
+                Arguments.of("13.0.0", true),
+                Arguments.of("14.0.0", true),
+                Arguments.of("15.0.0", true),
+                Arguments.of("16.0.0", true),
+                Arguments.of("17.0.0", true),
+                Arguments.of("17.0.6", true),
+                Arguments.of("17.0.7", false),
+                Arguments.of("17.0.8", false),
+                Arguments.of("17.0.9", false),
+                Arguments.of("18.0.0", true),
+                Arguments.of("19.0.0", true),
+                Arguments.of("20.0.1", false),
+                Arguments.of("21.0.0", false),
+                Arguments.of("21.0.1", false),
+                Arguments.of("21.0.2", false),
+                Arguments.of("22.0.0", false),
+                Arguments.of("22.0.1", false),
+                Arguments.of("22.0.2", false)
+        );
+    }
+}

--- a/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
+++ b/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2023, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.gluonhq.substrate.model;
 
 import com.gluonhq.substrate.ProjectConfiguration;


### PR DESCRIPTION
The GraalVM version check does not allow the latest GraalVM for JDK 17 / 20 to be used as it reports the JDK version instead of the old GraalVM version numbering.

### Issue

Fixes #1221

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)