### PR TITLE
added support for graalvm version strings without minor version

### DIFF
--- a/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/model/InternalProjectConfiguration.java
@@ -133,7 +133,7 @@ public class InternalProjectConfiguration {
     }
 
     static Version parseGraalVersion(String versionString) {
-        String pattern = "GraalVM (\\d{1,2}(\\.\\d+){0,2})";
+        String pattern = "GraalVM .*?(\\d{1,2}(\\.\\d+){0,2})";
         Pattern r = Pattern.compile(pattern);
         Matcher m = r.matcher(versionString);
         if (!m.find())

--- a/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
+++ b/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
@@ -129,7 +129,15 @@ class InternalProjectConfigurationTest {
                 // graalvm-jdk-21.0.1+12.1
                 Arguments.of(new Version("21.0.1"), new Version("21.0.1"), "java version \"21.0.1\" 2023-10-17\n" +
                         "Java(TM) SE Runtime Environment Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19)\n" +
-                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19, mixed mode, sharing)")
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19, mixed mode, sharing)"),
+
+                Arguments.of(new Version("17.0.7"), new Version("17.0.7"), "openjdk version \"17.0.7\" 2023-04-18\n" +
+                        "OpenJDK Runtime Environment GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12)\n" +
+                        "OpenJDK 64-Bit Server VM GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12, mixed mode, sharing)"),
+
+                Arguments.of(new Version("21"), new Version("21"), "openjdk version \"21\" 2023-09-19\n" +
+                        "OpenJDK Runtime Environment GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
+                        "OpenJDK 64-Bit Server VM GraalVM CE 21+35.1 (build 21+35-jvmci-23.1-b15, mixed mode, sharing)")
 
         );
     }

--- a/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
+++ b/src/test/java/com/gluonhq/substrate/model/InternalProjectConfigurationTest.java
@@ -71,4 +71,67 @@ class InternalProjectConfigurationTest {
                 Arguments.of("22.0.2", false)
         );
     }
+
+    @ParameterizedTest
+    @MethodSource("graalVersionOutputs")
+    void testParseGraalVMVersion(Version graalVersion, Version javaVersion, String output) {
+        assertEquals(graalVersion.toString(), InternalProjectConfiguration.parseGraalVersion(output).toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("graalVersionOutputs")
+    void testParseGraalVMJavaVersion(Version graalVersion, Version javaVersion, String output) {
+        assertEquals(javaVersion.toString(), InternalProjectConfiguration.parseGraalVMJavaVersion(output).toString());
+    }
+
+    static Stream<Arguments> graalVersionOutputs() {
+        // outputs of 'java -version'
+        return Stream.of(
+                // ======== Gluon Builds ========
+
+                // graalvm-svm-java17-linux-gluon-22.1.0.1-Final
+                Arguments.of(new Version("22.1.0"), new Version("17.0.3"), "openjdk version \"17.0.3\" 2022-04-19\n" +
+                        "OpenJDK Runtime Environment GraalVM 22.1.0.1 (build 17.0.3+7-jvmci-22.1-b06)\n" +
+                        "OpenJDK 64-Bit Server VM GraalVM 22.1.0.1 (build 17.0.3+7-jvmci-22.1-b06, mixed mode, sharing)"),
+
+                // graalvm-svm-java17-windows-gluon-22.0.0.3-Final
+                Arguments.of(new Version("22.0.0"), new Version("17.0.2"), "openjdk version \"17.0.2\" 2022-01-18\n" +
+                        "OpenJDK Runtime Environment GraalVM 22.0.0.2 (build 17.0.2+8-jvmci-22.0-b05)\n" +
+                        "OpenJDK 64-Bit Server VM GraalVM 22.0.0.2 (build 17.0.2+8-jvmci-22.0-b05, mixed mode, sharing)"),
+
+                // graalvm-svm-java17-windows-gluon-22.1.0.1-Final
+                Arguments.of(new Version("22.1.0"), new Version("17.0.3"), "openjdk version \"17.0.3\" 2022-04-19\n" +
+                        "OpenJDK Runtime Environment GraalVM 22.1.0.1 (build 17.0.3+7-jvmci-22.1-b06)\n" +
+                        "OpenJDK 64-Bit Server VM GraalVM 22.1.0.1 (build 17.0.3+7-jvmci-22.1-b06, mixed mode, sharing)"),
+
+                // ======== Oracle Builds ========
+
+                // graalvm-jdk-17.0.7+8.1
+                Arguments.of(new Version("17.0.7"), new Version("17.0.7"), "java version \"17.0.7\" 2023-04-18 LTS\n" +
+                        "Java(TM) SE Runtime Environment Oracle GraalVM 17.0.7+8.1 (build 17.0.7+8-LTS-jvmci-23.0-b12)\n" +
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 17.0.7+8.1 (build 17.0.7+8-LTS-jvmci-23.0-b12, mixed mode, sharing)"),
+
+                // graalvm-jdk-20.0.1+9.1
+                Arguments.of(new Version("20.0.1"), new Version("20.0.1"), "java version \"20.0.1\" 2023-04-18\n" +
+                        "Java(TM) SE Runtime Environment Oracle GraalVM 20.0.1+9.1 (build 20.0.1+9-jvmci-23.0-b12)\n" +
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 20.0.1+9.1 (build 20.0.1+9-jvmci-23.0-b12, mixed mode, sharing)"),
+
+                // graalvm-jdk-21+35.1
+                Arguments.of(new Version("21"), new Version("21"), "java version \"21\" 2023-09-19\n" +
+                        "Java(TM) SE Runtime Environment Oracle GraalVM 21+35.1 (build 21+35-jvmci-23.1-b15)\n" +
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21+35.1 (build 21+35-jvmci-23.1-b15, mixed mode, sharing)"),
+
+                // graalvm-jdk-17.0.9+11.1
+                Arguments.of(new Version("17.0.9"), new Version("17.0.9"), "java version \"17.0.9\" 2023-10-17 LTS\n" +
+                        "Java(TM) SE Runtime Environment Oracle GraalVM 17.0.9+11.1 (build 17.0.9+11-LTS-jvmci-23.0-b21)\n" +
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 17.0.9+11.1 (build 17.0.9+11-LTS-jvmci-23.0-b21, mixed mode, sharing)"),
+
+                // graalvm-jdk-21.0.1+12.1
+                Arguments.of(new Version("21.0.1"), new Version("21.0.1"), "java version \"21.0.1\" 2023-10-17\n" +
+                        "Java(TM) SE Runtime Environment Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19)\n" +
+                        "Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.1+12.1 (build 21.0.1+12-jvmci-23.1-b19, mixed mode, sharing)")
+
+        );
+    }
+
 }


### PR DESCRIPTION
Substrate currently fails for some GraalVM builds that print versions without minor revision numbers, e.g., `graalvm-jdk-21+35.1/bin/java -version`

```bash
java version "21" 2023-09-19
Java(TM) SE Runtime Environment Oracle GraalVM 21+35.1 (build 21+35-jvmci-23.1-b15)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21+35.1 (build 21+35-jvmci-23.1-b15, mixed mode, sharing)
```

This PR changes the Regex from `GraalVM .*?(\d\d.\d.\d)` to  `GraalVM (\d{1,2}(\.\d+){0,2})` (same as for the Java version) and adds unit tests for a variety of old and new GraalVM builds on different platforms 

### Current Regex

[GraalVM .*?(\d\d.\d.\d)](https://regex101.com/r/CPZMHR/1)

![image](https://github.com/gluonhq/substrate/assets/5491587/95627a35-c584-4104-934c-0492099de908)

### Updated Regex

[GraalVM (\d{1,2}(\.\d+){0,2})](https://regex101.com/r/DHE4ti/2)

![image](https://github.com/gluonhq/substrate/assets/5491587/4982e435-5933-474e-aa58-f04d9d81c76d)


- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)