### PR TITLE
Make ie4uinit.exe execution optional

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -285,6 +285,7 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     // During development if user changes the application icon, the same is not reflected immediately in Explorer.
     // To fix this, a cache clearance of the Windows explorer is required.
     private void clearExplorerCache() throws IOException, InterruptedException {
+        if (!executableOnPath("ie4uinit.exe")) return;
         ProcessRunner clearCache = new ProcessRunner("ie4uinit");
         clearCache.addArg(findCacheFlag());
         clearCache.runProcess("Clear Explorer cache");
@@ -309,6 +310,26 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
             Logger.logInfo("Unable to find Windows build version. Defaulting cache flag to '-show'.");
         }
         return flag;
+    }
+
+    /**
+     * Returns whether the passed executable is available on the PATH.
+     * For best result, the extension should be included in the executable, as "foo" will return true for "foo.bat".
+     * But running "foo" in a ProcessBuilder will look for "foo.exe" and fail to run.
+     *
+     * @param executable name of the executable to check
+     * @return true if the executable is available on the PATH.
+     */
+    private boolean executableOnPath(String executable) {
+        try {
+            ProcessRunner whereProcess = new ProcessRunner("cmd.exe", "/c", "where", "/q", executable);
+            whereProcess.showSevereMessage(false);
+            int exit = whereProcess.runProcess("find executable");
+            return exit == 0;
+        } catch (IOException | InterruptedException e) {
+            Logger.logInfo(String.format("Unable to validate if %s is available on the PATH, assuming it is not.", executable));
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/WindowsTargetConfiguration.java
@@ -285,7 +285,10 @@ public class WindowsTargetConfiguration extends AbstractTargetConfiguration {
     // During development if user changes the application icon, the same is not reflected immediately in Explorer.
     // To fix this, a cache clearance of the Windows explorer is required.
     private void clearExplorerCache() throws IOException, InterruptedException {
-        if (!executableOnPath("ie4uinit.exe")) return;
+        if (!executableOnPath("ie4uinit.exe")) {
+            Logger.logInfo("The application icon cache could not be cleared. As a result, the icon may not have been updated properly.");
+            return;
+        }
         ProcessRunner clearCache = new ProcessRunner("ie4uinit");
         clearCache.addArg(findCacheFlag());
         clearCache.runProcess("Clear Explorer cache");


### PR DESCRIPTION
- Do not run ie4uinit if it is not on the PATH.
- Uses 'where' to check if an executable is on the PATH

### Issue

Build on WindowsServerCore containers fail because `ie4uinit` does not exist.

Fixes #1239

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)