### PR TITLE
Use GITHUB_TOKEN to commit in release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           git commit gradle.properties -m "Prepare development of $newVersion"
           git push https://gluon-bot:$PAT@github.com/$GITHUB_REPOSITORY HEAD:master
         env:
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GITHUB_TOKEN }}
 
   release-notes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Last release](https://github.com/gluonhq/substrate/actions/runs/10006896993) failed as it wasn't able to commit the new development version.