### PR TITLE
checkout repository to use release script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           persist-credentials: false
@@ -71,6 +71,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ release ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
+          persist-credentials: false
       - run: |
           TAG=${GITHUB_REF/refs\/tags\//}
           bash $GITHUB_WORKSPACE/.github/scripts/release-plugins.sh $TAG $PAT


### PR DESCRIPTION
`release-gluonfx-plugins` is failing as it needs the repository files to run successfully