### PR TITLE
macOS fixes

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AbstractTargetConfiguration.java
@@ -405,7 +405,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
     private String getJniPlatform() {
         Triplet target = projectConfiguration.getTargetTriplet();
         Version graalVersion = projectConfiguration.getGraalVersion();
-        boolean graalVM221 = ((graalVersion.getMajor() > 21) && (graalVersion.getMinor() > 0));
+        boolean graalVM221or23 = graalVersion.getMajor() > 22 || (graalVersion.getMajor() > 21 && graalVersion.getMinor() > 0);
         String os = target.getOs();
         String arch = target.getArch();
         switch (os) {
@@ -429,7 +429,7 @@ public abstract class AbstractTargetConfiguration implements TargetConfiguration
             case Constants.OS_DARWIN:
                 switch (arch) {
                     case Constants.ARCH_AMD64:
-                        return graalVM221 ? "MACOS_AMD64" : "DARWIN_AMD64";
+                        return graalVM221or23 ? "MACOS_AMD64" : "DARWIN_AMD64";
                     case Constants.ARCH_AARCH64:
                         return "MACOS_AARCH64";
                     default:

--- a/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/MacOSTargetConfiguration.java
@@ -27,6 +27,7 @@
  */
 package com.gluonhq.substrate.target;
 
+import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.model.InternalProjectConfiguration;
 import com.gluonhq.substrate.model.ProcessPaths;
 import com.gluonhq.substrate.util.FileOps;
@@ -46,7 +47,8 @@ import java.util.stream.Collectors;
 
 public class MacOSTargetConfiguration extends DarwinTargetConfiguration {
 
-    private static final String MIN_MACOS_VERSION = "11";
+    private static final String MIN_MACOS_VERSION_AMD64 = "11";
+    private static final String MIN_MACOS_VERSION_AARCH64 = "12";
 
     private static final List<String> javaDarwinLibs = Arrays.asList("pthread", "z", "dl", "stdc++");
     private static final List<String> javaDarwinFrameworks = Arrays.asList("Foundation", "AppKit");
@@ -65,9 +67,11 @@ public class MacOSTargetConfiguration extends DarwinTargetConfiguration {
             "icui18n", "SqliteJava", "XSLTJava", "PAL", "WebCoreTestSupport",
             "WTF", "icuuc", "icudata"
     );
+    private final String minVersion;
 
     public MacOSTargetConfiguration(ProcessPaths paths, InternalProjectConfiguration configuration) {
         super(paths, configuration);
+        minVersion = Constants.ARCH_AMD64.equals(projectConfiguration.getTargetTriplet().getArch()) ? MIN_MACOS_VERSION_AMD64 : MIN_MACOS_VERSION_AARCH64;
     }
 
     @Override
@@ -93,14 +97,14 @@ public class MacOSTargetConfiguration extends DarwinTargetConfiguration {
 
     @Override
     List<String> getTargetSpecificCCompileFlags() {
-        return Arrays.asList("-mmacosx-version-min=" + MIN_MACOS_VERSION);
+        return Arrays.asList("-mmacosx-version-min=" + minVersion);
     }
 
     @Override
     List<String> getTargetSpecificLinkFlags(boolean useJavaFX, boolean usePrismSW) {
         List<String> linkFlags = new ArrayList<>(asListOfLibraryLinkFlags(javaDarwinLibs));
 
-        linkFlags.add("-mmacosx-version-min=" + MIN_MACOS_VERSION);
+        linkFlags.add("-mmacosx-version-min=" + minVersion);
         if (projectConfiguration.isSharedLibrary()) {
             linkFlags.addAll(Arrays.asList(
                     "-shared",


### PR DESCRIPTION
Follow up of #1241, macOS for AMD64 failed to select correct Platform, and uses a min lower version than macOS for AArch64