### PR TITLE
Consider system bars insets to avoid edge to edge display, bump versions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/native/android/android_project/app/build.gradle
+++ b/src/main/resources/native/android/android_project/app/build.gradle
@@ -18,14 +18,16 @@ android {
         mavenCentral()
         google()
         maven {
+            url "https://central.sonatype.com/repository/maven-snapshots/"
+        }
+        maven {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
         mavenLocal()
     }
 
     dependencies {
-        implementation 'com.android.support:support-v4:28.0.0'
-        annotationProcessor 'com.android.support:support-annotations:28.0.0'
+        implementation 'androidx.activity:activity:1.10.1'
         // OTHER_ANDROID_DEPENDENCIES
         api fileTree(dir: '../libs', include: '*.aar')
         api fileTree(dir: '../libs', include: '*.jar')

--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -58,6 +58,10 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
 import java.util.TimeZone;
 import javafx.scene.input.KeyCode;
 
@@ -95,6 +99,13 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
         mViewGroup.addView(mView);
         setContentView(mViewGroup);
         instance = this;
+
+        // Apply edge-to-edge display
+        ViewCompat.setOnApplyWindowInsetsListener(mView, (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
 
         imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         Log.v(TAG, "onCreate done");

--- a/src/main/resources/native/android/android_project/build.gradle
+++ b/src/main/resources/native/android/android_project/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.2'
+        classpath 'com.android.tools.build:gradle:8.11.0'
     }
 }
 


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1328 

In theory, `ViewCompat.setOnApplyWindowInsetsListener` API will prevent the warnings from Google Play, about the app  not taking into consideration the Edge To Edge display.

This fix avoids further changes (making the system bars transparent, for instance), and keeps the current status. However, we should consider the benefits of the Edge To Edge approach in the future.

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)