### PR TITLE
Bump NDK version

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -66,7 +66,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
 
     private static final String ANDROID_TRIPLET = new Triplet(Constants.Profile.ANDROID).toString();
     private static final String ANDROID_MIN_SDK_VERSION = "21";
-    public static final String ANDROID_NDK_VERSION = "26.3.11579264";
+    public static final String ANDROID_NDK_VERSION = "28.2.13676358";
     private static final List<String> ANDROID_KEYSTORE_EXTENSIONS = List.of(".keystore", ".jks");
     private static final String WL_WHOLE_ARCHIVE = "-Wl,--whole-archive";
     private static final String WL_NO_WHOLE_ARCHIVE = "-Wl,--no-whole-archive";


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1330 

According to https://developer.android.com/guide/practices/page-sizes#compile-r28, NDK version r28 and higher compile 16 KB-aligned by default.

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)