### PR TITLE
Android: Apply insets to decorView

### DIFF
--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -32,6 +32,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.SystemClock;
@@ -41,20 +42,20 @@ import android.text.Selection;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
-import android.view.inputmethod.InputConnection;
-
 import android.view.KeyEvent;
 import android.view.KeyCharacterMap;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 
@@ -100,12 +101,17 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
         setContentView(mViewGroup);
         instance = this;
 
-        // Apply edge-to-edge display
-        ViewCompat.setOnApplyWindowInsetsListener(mView, (v, insets) -> {
-            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
-            return insets;
-        });
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // > 34
+            // Prevent edge-to-edge display, keeping the view outside the systemBars
+            // Warning: this doesn't set the color of the SystemBars, which can be done
+            // by the StatusBarService in Attach
+            View decorView = getWindow().getDecorView();
+            ViewCompat.setOnApplyWindowInsetsListener(decorView, (v, insets) -> {
+                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                decorView.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+                return insets;
+            });
+        }
 
         imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         Log.v(TAG, "onCreate done");


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1332

This PR adds the SystemBar insets to the Activity->Window->DecorView, so the app doesn't extend edge-to-edge, preventing the overlapping with the SystemBars.

<img width="353" height="782" alt="image" src="https://github.com/user-attachments/assets/1bb41c96-bff4-4055-bf5c-197ce1ca2dc5" />

As a consequence, for Android 15+, the SystemBars are translucent and the color should be set via the Attach StatusBarService:
 
<img width="352" height="782" alt="image" src="https://github.com/user-attachments/assets/90eb3edf-358d-4680-b255-238ee5798816" />


### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)