### PR TITLE
Filter on provided provisioning profile if set for macOS/iOS code signing

### DIFF
--- a/src/main/java/com/gluonhq/substrate/util/ios/CodeSigning.java
+++ b/src/main/java/com/gluonhq/substrate/util/ios/CodeSigning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Gluon
+ * Copyright (c) 2019, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -141,12 +141,9 @@ public class CodeSigning {
             for (Identity identity : identities) {
                 mobileProvision = findMobileProvision(identity, bundleId, bundleId);
                 if (mobileProvision != null) {
-                    if (providedMobileProvision == null
-                            || providedMobileProvision.equals(mobileProvision.getName())) {
-                        this.identity = identity;
-                        Logger.logDebug("Got provisioning profile: " + mobileProvision.getName());
-                        return mobileProvision;
-                    }
+                    this.identity = identity;
+                    Logger.logDebug("Got provisioning profile: " + mobileProvision.getName());
+                    return mobileProvision;
                 }
             }
             Logger.logInfo("Warning, getProvisioningProfile is failing");
@@ -159,6 +156,7 @@ public class CodeSigning {
         return retrieveValidMobileProvisions().stream()
                 .filter(provision -> filterByIdentifier(provision, bundleId))
                 .filter(provision -> filterByCertificate(provision, identity))
+                .filter(this::filterByProvidedProvision)
                 .findFirst()
                 .orElseGet(() -> tryModifiedBundleId(identity, bundleId, initialBundleId));
     }
@@ -180,6 +178,17 @@ public class CodeSigning {
                     Logger.logDebug("App identifiers match, but there are not fingerprint matches");
                     return false;
                 });
+    }
+
+    private boolean filterByProvidedProvision(MobileProvision provision) {
+        if (providedMobileProvision == null) {
+            return true;
+        }
+        boolean match = providedMobileProvision.equals(provision.getName());
+        Logger.logDebug("Provision profile " + provision.getName() +
+                (match ? " matches the provided one" : " doesn't match the provided one"));
+        return match;
+
     }
 
     private MobileProvision tryModifiedBundleId(Identity identity, String bundleId, String initialBundleId) {

--- a/src/main/java/com/gluonhq/substrate/util/macos/CodeSigning.java
+++ b/src/main/java/com/gluonhq/substrate/util/macos/CodeSigning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Gluon
+ * Copyright (c) 2019, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -372,8 +372,6 @@ public class CodeSigning {
             provisionProfile = identities.stream()
                     .map(id -> findProvisionProfile(id, bundleId))
                     .filter(Objects::nonNull)
-                    .filter(profile -> providedProvisionProfile == null
-                            || providedProvisionProfile.equals(profile.getName()))
                     .findFirst()
                     .orElse(null);
         }
@@ -386,6 +384,7 @@ public class CodeSigning {
         return retrieveValidProvisionProfiles().stream()
                 .filter(provision -> filterByIdentifier(provision, bundleId))
                 .filter(provision -> filterByCertificate(provision, identity))
+                .filter(this::filterByProvidedProvision)
                 .findFirst()
                 .orElse(null);
     }
@@ -448,5 +447,16 @@ public class CodeSigning {
                     Logger.logDebug("App identifiers match, but there are not fingerprint matches");
                     return false;
                 });
+    }
+
+    private boolean filterByProvidedProvision(ProvisionProfile provision) {
+        if (providedProvisionProfile == null) {
+            return true;
+        }
+        boolean match = providedProvisionProfile.equals(provision.getName());
+        Logger.logDebug("Provision profile " + provision.getName() +
+                (match ? " matches the provided one" : " doesn't match the provided one"));
+        return match;
+
     }
 }


### PR DESCRIPTION


<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1345

Before the PR, we filtered provisioning profiles on identifier and certificate then, picked the first one not null, and then verified it matched the provided profile (or true if not set).

With this PR, we filter provisioning profiles on identifier and certificate _and_ provided profile (or true if not set), and then, pick the first one not null.

Therefore, we don't exclude all possible coincidences of identifier and certificate when comparing with the provided profile, if set.

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)