### PR TITLE
Simplify BasicInputConnection implementation and remove composedText

### DIFF
--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -237,16 +237,22 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
     }
 
     /**
-     * External call that sets the Android InputType keyboard. Triggers a restartInput so the change takes
-     * effect immediately if the keyboard is already visible.
+     * External call that sets the Android InputType keyboard. Triggers a
+     * {@code restartInput} so the change takes effect immediately if the
+     * keyboard is already visible. Idempotent: if the requested type already
+     * equals the current one, no {@code restartInput} is performed, avoiding
+     * an unnecessary {@link #onCreateInputConnection(EditorInfo)} round trip.
      */
     static void setKeyboardType(int keyboardTypeValue) {
-        currentInputType = mapKeyboardTypeToInputType(keyboardTypeValue);
-        Log.d(TAG, "setKeyboardType: keyboardTypeValue=" + keyboardTypeValue + " -> inputType=" + currentInputType);
+        int newInputType = mapKeyboardTypeToInputType(keyboardTypeValue);
+        if (newInputType == currentInputType) {
+            Log.d(TAG, "setKeyboardType: unchanged inputType=" + newInputType);
+            return;
+        }
+        currentInputType = newInputType;
+        Log.d(TAG, "setKeyboardType: keyboardTypeValue=" + keyboardTypeValue + " -> inputType=" + newInputType);
         if (imm != null && mView != null) {
-            instance.runOnUiThread(() -> {
-                imm.restartInput(mView);
-            });
+            instance.runOnUiThread(() -> imm.restartInput(mView));
         }
     }
 

--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -32,12 +32,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.SystemClock;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Selection;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
@@ -282,18 +282,6 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
     private native void nativeGotTouchEvent(int pcount, int[] actions, int[] ids, int[] touchXs, int[] touchYs);
     private native void nativeDispatchKeyEvent(int type, int key, char[] chars, int charCount, int modifiers);
 
-    /**
-     * Forwards the final composed text to the JavaFX layer via attach_adapter.c,
-     * without the internals of the BasicInputConnection (like deleting chars and typing
-     * them all over again while composing the resulting text).
-     * <p>Note that listeners attached to the JavaFX text input control {@code textProperty()} will still
-     * catch all those internals, so this is a convenient method to export to the JavaFX layer
-     * only the final composed text instead</p>
-     *
-     * @param id   the JavaFX Node id of the active text control
-     * @param text the full text content for that control
-     */
-    private native void nativeNotifyComposingText(String id, String text);
 
     private native void nativeDispatchLifecycleEvent(String event);
     private native void nativeDispatchActivityResult(int requestCode, int resultCode, Intent intent);
@@ -307,12 +295,15 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
         private final KeyEvent ENTER_DOWN_EVENT = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER);
         private final KeyEvent ENTER_UP_EVENT = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER);
 
-        private String currentComposingText = "";
-        
         /**
          * Map of currently composed text per Text Input control (identifyed by its id).
+         * It is used to restart the IME {@link Editable} across keyboard switches / focus
+         * changes. The map is only accurate as long as the JavaFX control is not modified
+         * outside of the IME.</p>
          */
         private final HashMap<String, String> composedTexts = new HashMap<>();
+
+        private BaseInputConnection inputConnection;
 
         public InternalSurfaceView(Context context) {
             super(context);
@@ -382,83 +373,92 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
             outAttrs.inputType = currentInputType;
             // Remove top textfield editor on landscape
             outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI;
-            // A new IME session is starting (keyboard shown, field focused, etc.).
-            // Reset the composing text and the simulated text for the active node
-            currentComposingText = "";
             composedTexts.putIfAbsent(currentActiveNodeId, "");
+            final String initialText = composedTexts.get(currentActiveNodeId);
+            outAttrs.initialSelStart = initialText.length();
+            outAttrs.initialSelEnd = initialText.length();
 
-            return new BaseInputConnection(this, true) {
+            // for every override that follows, we take the content before and after
+            // calling super, and we sync the native editor with the JavaFX control
+            inputConnection = new BaseInputConnection(this, true) {
 
                 @Override
                 public boolean setComposingText(CharSequence text, int newCursorPosition) {
-                    int deleteCount = currentComposingText.length();
-                    currentComposingText = text.toString();
+                    Editable content = getEditable();
+                    String before = content.toString();
                     boolean result = super.setComposingText(text, newCursorPosition);
-                    // Send individual key events (backspaces + typed text).
-                    resetText(deleteCount);
-                    processAndroidKeyEvent(new KeyEvent(SystemClock.uptimeMillis(), text.toString(), -1, 0));
-                    // Update composed text with one call
-                    updateComposedText(deleteCount, text.toString());
+                    syncEditor(before, content.toString());
                     return result;
                 }
 
                 @Override
                 public boolean commitText(CharSequence text, int newCursorPosition) {
-                    int deleteCount = currentComposingText.length();
-                    currentComposingText = "";
+                    Editable content = getEditable();
+                    String before = content.toString();
+                    boolean isEnter = ENTER_STRING.equals(text == null ? "" : text.toString());
                     boolean result = super.commitText(text, newCursorPosition);
-                    if (ENTER_STRING.equals(text.toString())) {
-                        // Clear composing region, then fire Enter.
-                        resetText(deleteCount);
-                        // Composed text is gone before the Enter key.
-                        updateComposedText(deleteCount, "");
+                    if (isEnter) {
+                        // strip '\n' and fire Enter as a key event.
+                        int last = content.length() - 1;
+                        if (last >= 0 && content.charAt(last) == '\n') {
+                            content.delete(last, last + 1);
+                        }
+                        syncEditor(before, content.toString());
                         processAndroidKeyEvent(ENTER_DOWN_EVENT);
                         processAndroidKeyEvent(ENTER_UP_EVENT);
-                    } else {
-                        // backspaces to erase composing text, then insert committed word.
-                        resetText(deleteCount);
-                        processAndroidKeyEvent(new KeyEvent(SystemClock.uptimeMillis(), text.toString(), -1, 0));
-                        // committed word replaces the composing region at once.
-                        updateComposedText(deleteCount, text.toString());
+                        return result;
                     }
-                    return result;
-                }
-
-                @Override
-                public boolean finishComposingText() {
-                    currentComposingText = "";
-                    boolean result = super.finishComposingText();
-                    Editable content = getEditable();
-                    if (content != null) {
-                        content.clear();
-                    }
+                    syncEditor(before, content.toString());
                     return result;
                 }
 
                 @Override
                 public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-                    // Explicit user deletion (e.g. hardware backspace).
+                    Editable content = getEditable();
+                    String before = content.toString();
                     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
-                    int length = beforeLength - afterLength;
-                    // individual backspace key events.
-                    resetText(length);
-                    // sync with the explicit deletion at once.
-                    updateComposedText(length, "");
+                    syncEditor(before, content.toString());
                     return result;
                 }
-
-                private void resetText(int length) {
-                    for (int i = 0; i < length; i++) {
-                        processAndroidKeyEvent(BACK_DOWN_EVENT);
-                        processAndroidKeyEvent(BACK_UP_EVENT);
-                    }
-                }
             };
+
+            // Set cached text and place the cursor at its end.
+            Editable editable = inputConnection.getEditable();
+            if (editable != null) {
+                editable.replace(0, editable.length(), initialText);
+                Selection.setSelection(editable, initialText.length());
+            }
+            Log.d(TAG, "onCreateInputConnection Editable set with '" + initialText + "'");
+            return inputConnection;
+        }
+
+        /**
+         * Send the key events (backspaces + typed characters) needed to transform the editor
+         * from {@code before} to {@code after}.
+         * Also update the per-node cache for future IME sessions.
+         */
+        private void syncEditor(String before, String after) {
+            if (before.equals(after)) {
+                return;
+            }
+            int common = 0;
+            int min = Math.min(before.length(), after.length());
+            while (common < min && before.charAt(common) == after.charAt(common)) {
+                common++;
+            }
+            for (int i = before.length() - common; i > 0; i--) {
+                processAndroidKeyEvent(BACK_DOWN_EVENT);
+                processAndroidKeyEvent(BACK_UP_EVENT);
+            }
+            if (common < after.length()) {
+                processAndroidKeyEvent(new KeyEvent(SystemClock.uptimeMillis(), after.substring(common), -1, 0));
+            }
+            composedTexts.put(currentActiveNodeId, after);
         }
 
         @Override
         public boolean dispatchKeyEvent(final KeyEvent event) {
-            Log.v(TAG, "Activity, process get key event, action = "+event);
+            Log.v(TAG, "Activity, process get key event, action = " + event);
             boolean consume = true;
             if (event.getAction() == KeyEvent.ACTION_DOWN &&
                     (event.getKeyCode() == KeyEvent.KEYCODE_VOLUME_UP ||
@@ -467,21 +467,17 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
                 // let Android OS handle volume events
                 consume = false;
             }
-            if (event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+            if (event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_DEL
+                    && inputConnection != null) {
                 // sync after direct backspace key presses.
-                updateComposedText(1, "");
+                Editable content = inputConnection.getEditable();
+                if (content != null && content.length() > 0) {
+                    content.delete(content.length() - 1, content.length());
+                    composedTexts.put(currentActiveNodeId, content.toString());
+                }
             }
             processAndroidKeyEvent(event);
             return consume;
-        }
-
-        private void updateComposedText(int deleteCount, String text) {
-            String id = currentActiveNodeId;
-            String current = composedTexts.getOrDefault(id, "");
-            String updated = current.substring(0, current.length() - Math.min(deleteCount, current.length())) + text;
-            composedTexts.put(id, updated);
-            Log.d(TAG, "updateComposedText [" + id + "]: TextInputControl shows: '" + updated + "'");
-            nativeNotifyComposingText(id, updated);
         }
 
         private final Handler handler = new Handler();

--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -239,9 +239,7 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
     /**
      * External call that sets the Android InputType keyboard. Triggers a
      * {@code restartInput} so the change takes effect immediately if the
-     * keyboard is already visible. Idempotent: if the requested type already
-     * equals the current one, no {@code restartInput} is performed, avoiding
-     * an unnecessary {@link #onCreateInputConnection(EditorInfo)} round trip.
+     * keyboard is already visible.
      */
     static void setKeyboardType(int keyboardTypeValue) {
         int newInputType = mapKeyboardTypeToInputType(keyboardTypeValue);

--- a/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
+++ b/src/main/resources/native/android/android_project/app/src/main/java/com/gluonhq/helloandroid/MainActivity.java
@@ -228,8 +228,8 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
     }
 
     /**
-     * External call that passes the JavaFX text control that is currently active, so composing text
-     * can be tagged with the correct id.
+     * External call that passes the id of the JavaFX text control that is currently active,
+     * so the map of composedTexts can keep track of the current content of each editor per id.
      */
     static void setActiveNodeId(String id) {
         Log.d(TAG, "setActiveNodeId: " + currentActiveNodeId);

--- a/src/main/resources/native/android/c/attach_adapter.c
+++ b/src/main/resources/native/android/c/attach_adapter.c
@@ -43,13 +43,3 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeDispatch
     attach_setActivityResult(requestCode, resultCode, intent);
 }
 
-// keyboard: Composing text (IME predictive text for node with id)
-JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeNotifyComposingText(JNIEnv *env, jobject activity, jstring id, jstring text)
-{
-    const char *idChars = (*env)->GetStringUTFChars(env, id, NULL);
-    const char *textChars = (*env)->GetStringUTFChars(env, text, NULL);
-    LOGE(stderr, "Dispatching composing text from native Dalvik layer: id=%s, text=%s", idChars, textChars);
-    attach_setComposingText(idChars, textChars);
-    (*env)->ReleaseStringUTFChars(env, text, textChars);
-    (*env)->ReleaseStringUTFChars(env, id, idChars);
-}

--- a/src/main/resources/native/android/c/grandroid_ext.h
+++ b/src/main/resources/native/android/c/grandroid_ext.h
@@ -58,11 +58,9 @@ jobject substrateGetActivity();
 #ifdef SUBSTRATE
 void __attribute__((weak)) attach_setActivityResult(jint requestCode, jint resultCode, jobject intent) {}
 void __attribute__((weak)) attach_setLifecycleEvent(const char *event) {}
-void __attribute__((weak)) attach_setComposingText(const char *id, const char *text) {}
 #else
 void attach_setActivityResult(jint requestCode, jint resultCode, jobject intent);
 void attach_setLifecycleEvent(const char *event);
-void attach_setComposingText(const char *id, const char *text);
 #endif
 
 #define ATTACH_GRAAL() \


### PR DESCRIPTION
This PR is a follow up of #1346 

- It simplifies and improves the BasicInputConnection implementation for Android, fixing several issues.
- It withdraws the composedText: there is no point in tracking the text of the native editor, given that there is no communication from JavaFX text editor to Android editor:  any change to the former (via setText or paste) won't be sent to Android, and the composedText will be out of sync.
- It fixes the call to set the keyboard type, preventing unnecessary restarts