### PR TITLE
Suppress EGL loop when Android surface is destroyed

### DIFF
--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Gluon
+ * Copyright (c) 2019, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -88,8 +88,8 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     private final List<String> cFlags = new ArrayList<>(Arrays.asList("-target", ANDROID_TRIPLET, "-I.", "-fPIC"));
     private final List<String> linkFlags = Arrays.asList("-target",
             ANDROID_TRIPLET + ANDROID_MIN_SDK_VERSION, "-fPIC",
-            "-Wl,--rosegment,--gc-sections,-z,noexecstack", "-shared",
-            "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++", "-Wl,--wrap=eglSwapBuffers");
+            "-Wl,--rosegment,--gc-sections,-z,noexecstack", "-Wl,--wrap=eglSwapBuffers", "-shared",
+            "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++");
     private final List<String> javafxLinkFlags = new ArrayList<>(Arrays.asList(WL_WHOLE_ARCHIVE,
             "-lprism_es2_monocle", "-lglass_monocle", "-ljavafx_font_freetype", "-ljavafx_iio", WL_NO_WHOLE_ARCHIVE,
             "-lGLESv2", "-lEGL", "-lfreetype"));

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -89,7 +89,7 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     private final List<String> linkFlags = Arrays.asList("-target",
             ANDROID_TRIPLET + ANDROID_MIN_SDK_VERSION, "-fPIC",
             "-Wl,--rosegment,--gc-sections,-z,noexecstack", "-shared",
-            "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++");
+            "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++", "-Wl,--wrap=eglSwapBuffers");
     private final List<String> javafxLinkFlags = new ArrayList<>(Arrays.asList(WL_WHOLE_ARCHIVE,
             "-lprism_es2_monocle", "-lglass_monocle", "-ljavafx_font_freetype", "-ljavafx_iio", WL_NO_WHOLE_ARCHIVE,
             "-lGLESv2", "-lEGL", "-lfreetype"));

--- a/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
+++ b/src/main/java/com/gluonhq/substrate/target/AndroidTargetConfiguration.java
@@ -88,8 +88,9 @@ public class AndroidTargetConfiguration extends PosixTargetConfiguration {
     private final List<String> cFlags = new ArrayList<>(Arrays.asList("-target", ANDROID_TRIPLET, "-I.", "-fPIC"));
     private final List<String> linkFlags = Arrays.asList("-target",
             ANDROID_TRIPLET + ANDROID_MIN_SDK_VERSION, "-fPIC",
-            "-Wl,--rosegment,--gc-sections,-z,noexecstack", "-Wl,--wrap=eglSwapBuffers", "-shared",
-            "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++");
+            "-Wl,--rosegment,--gc-sections,-z,noexecstack",
+            "-Wl,--wrap=eglSwapBuffers", "-Wl,--wrap=eglCreateWindowSurface",
+            "-shared", "-landroid", "-llog", "-lffi", "-llibchelper", "-static-libstdc++");
     private final List<String> javafxLinkFlags = new ArrayList<>(Arrays.asList(WL_WHOLE_ARCHIVE,
             "-lprism_es2_monocle", "-lglass_monocle", "-ljavafx_font_freetype", "-ljavafx_iio", WL_NO_WHOLE_ARCHIVE,
             "-lGLESv2", "-lEGL", "-lfreetype"));

--- a/src/main/resources/native/android/c/javafx_adapter.c
+++ b/src/main/resources/native/android/c/javafx_adapter.c
@@ -34,6 +34,7 @@
 static atomic_int egl_surface_valid = ATOMIC_VAR_INIT(0);
 
 extern EGLBoolean __real_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface);
+extern EGLSurface __real_eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EGLNativeWindowType win, const EGLint *attrib_list);
 
 #ifdef JAVAFX_WEB
 jclass nativeWebViewClass;
@@ -73,6 +74,8 @@ void registerJavaFXMethodHandles(JNIEnv *aenv)
 void registerJavaFXMethodHandles(JNIEnv *aenv) {}
 #endif
 
+// Avoid calling eglSwapBuffers when the surface is not valid (app is in the background and the native window has been
+// released), to prevent libEGL from spamming EGL_BAD_SURFACE errors.
 EGLBoolean __wrap_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface) {
     if (!atomic_load_explicit(&egl_surface_valid, memory_order_acquire)) {
         struct timespec ts = {0, 16000000L};
@@ -80,6 +83,15 @@ EGLBoolean __wrap_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface) {
         return EGL_FALSE;
     }
     return __real_eglSwapBuffers(dpy, surface);
+}
+
+// Avoid calling eglCreateWindowSurface with a stale/NULL window when the app is in the background and the native
+// window has been released, to prevent libEGL from spamming EGL_BAD_NATIVE_WINDOW errors.
+EGLSurface __wrap_eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EGLNativeWindowType win, const EGLint *attrib_list) {
+    if (!atomic_load_explicit(&egl_surface_valid, memory_order_acquire) || win == NULL) {
+        return EGL_NO_SURFACE;
+    }
+    return __real_eglCreateWindowSurface(dpy, config, win, attrib_list);
 }
 
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurface(JNIEnv *env, jobject activity, jobject surface)
@@ -103,6 +115,7 @@ JNIEXPORT jlong JNICALL Java_com_gluonhq_helloandroid_MainActivity_surfaceReady(
     window = ANativeWindow_fromSurface(env, surface);
     androidJfx_setNativeWindow(window);
     androidJfx_setDensity(mydensity);
+    atomic_store_explicit(&egl_surface_valid, 1, memory_order_release);
     LOGE(stderr, "SurfaceReady, native window at %p\n", window);
     density = mydensity;
     return (jlong)window;

--- a/src/main/resources/native/android/c/javafx_adapter.c
+++ b/src/main/resources/native/android/c/javafx_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Gluon
+ * Copyright (c) 2020, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,8 @@
  */
 #include <stdlib.h>
 #include <string.h>
+#include <EGL/egl.h>
+#include <stdatomic.h>
 #include "grandroid.h"
 
 static atomic_int egl_surface_valid = ATOMIC_VAR_INIT(0);
@@ -73,7 +75,7 @@ void registerJavaFXMethodHandles(JNIEnv *aenv) {}
 
 EGLBoolean __wrap_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface) {
     if (!atomic_load_explicit(&egl_surface_valid, memory_order_acquire)) {
-        struct timespec ts = {0, 16000000L};  // yield ~1 frame
+        struct timespec ts = {0, 16000000L};
         nanosleep(&ts, NULL);
         return EGL_FALSE;
     }
@@ -85,11 +87,11 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurfa
     LOGE(stderr, "nativeSetSurface called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
     if (surface != NULL) {
         window = ANativeWindow_fromSurface(env, surface);
-        atomic_store_explicit(&egl_surface_valid, 1, memory_order_release)
         androidJfx_setNativeWindow(window);
+        atomic_store_explicit(&egl_surface_valid, 1, memory_order_release);
         LOGE(stderr, "native setSurface Ready, native window at %p\n", window);
     } else {
-        atomic_store_explicit(&egl_surface_valid, 0, memory_order_release)
+        atomic_store_explicit(&egl_surface_valid, 0, memory_order_release);
         androidJfx_setNativeWindow(NULL);
         LOGE(stderr, "native setSurface was null");
     }

--- a/src/main/resources/native/android/c/javafx_adapter.c
+++ b/src/main/resources/native/android/c/javafx_adapter.c
@@ -29,6 +29,10 @@
 #include <string.h>
 #include "grandroid.h"
 
+static atomic_int egl_surface_valid = ATOMIC_VAR_INIT(0);
+
+extern EGLBoolean __real_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface);
+
 #ifdef JAVAFX_WEB
 jclass nativeWebViewClass;
 jobject nativeWebViewObj;
@@ -67,14 +71,25 @@ void registerJavaFXMethodHandles(JNIEnv *aenv)
 void registerJavaFXMethodHandles(JNIEnv *aenv) {}
 #endif
 
+EGLBoolean __wrap_eglSwapBuffers(EGLDisplay dpy, EGLSurface surface) {
+    if (!atomic_load_explicit(&egl_surface_valid, memory_order_acquire)) {
+        struct timespec ts = {0, 16000000L};  // yield ~1 frame
+        nanosleep(&ts, NULL);
+        return EGL_FALSE;
+    }
+    return __real_eglSwapBuffers(dpy, surface);
+}
+
 JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_MainActivity_nativeSetSurface(JNIEnv *env, jobject activity, jobject surface)
 {
     LOGE(stderr, "nativeSetSurface called, env at %p and size %ld, surface at %p\n", env, sizeof(JNIEnv), surface);
     if (surface != NULL) {
         window = ANativeWindow_fromSurface(env, surface);
+        atomic_store_explicit(&egl_surface_valid, 1, memory_order_release)
         androidJfx_setNativeWindow(window);
         LOGE(stderr, "native setSurface Ready, native window at %p\n", window);
     } else {
+        atomic_store_explicit(&egl_surface_valid, 0, memory_order_release)
         androidJfx_setNativeWindow(NULL);
         LOGE(stderr, "native setSurface was null");
     }


### PR DESCRIPTION
<!--- Provide a brief summary of the PR -->

### Issue

<!--- The issue this PR addresses -->
Fixes #1355, by patching Substrate with a fix that belongs in JavaFX (detecting when there is no native window and stopping the EGL calls)

### Progress

- [ ] Change must not contain extraneous whitespace
- [ ] License header year is updated, if required
- [ ] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)